### PR TITLE
Disable paper_trail in the test environment by default

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,5 +50,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-  # PaperTrail.enabled = false
+
+  config.after_initialize do
+    # Speed up tests by disabling audit by default
+    PaperTrail.enabled = false
+  end
 end

--- a/test/integration/audit_test.rb
+++ b/test/integration/audit_test.rb
@@ -34,75 +34,77 @@ class AuditTest < ActionDispatch::IntegrationTest
   end
 
   test 'auditing of team' do
-    # Create a new team:
-    visit organisation_path(@organisation)
+    with_versioning do
+      # Create a new team:
+      visit organisation_path(@organisation)
 
-    click_link 'Add', href: new_organisation_team_path(@organisation)
+      click_link 'Add', href: new_organisation_team_path(@organisation)
 
-    fill_in_team_data
-    click_button 'Save'
+      fill_in_team_data
+      click_button 'Save'
 
-    # Check there's one version of the Team:
-    page.find('#team-details-panel').click_link 'Audit'
-    assert page.has_content? 'Team Audit'
-    # First row is the header
-    assert page.has_selector?('table#version-table tr', count: 2)
-    page.find('#version-index-details').click_link 'Return to Team'
+      # Check there's one version of the Team:
+      page.find('#team-details-panel').click_link 'Audit'
+      assert page.has_content? 'Team Audit'
+      # First row is the header
+      assert page.has_selector?('table#version-table tr', count: 2)
+      page.find('#version-index-details').click_link 'Return to Team'
 
-    # TODO: The delegate user should be there already:
-    # page.assert_selector('#memberships-panel tbody tr', count: 1)
-    # Add a team member
-    within('#team_show_tabs') do
-      click_on 'Users'
-    end
-    click_on 'Edit team grants'
-    page.check("grants_users_#{users(:standard_user).id}_#{TeamRole.fetch(:mbis_applicant).id}")
-    find_button('Update Roles').click
-
-    # The now the standard user should be there too:
-    page.assert_selector('#memberships-panel tbody tr', count: 1)
-    # Check that a Membership version has been created:
-    page.find('#team-details-panel').click_link 'Audit'
-    assert page.has_content?('Grant')
-    # First row is the header
-    assert page.has_selector?('table#version-table tr', count: 3)
-    page.find('#version-table').click_link('Details', match: :first)
-    within_modal do
-      assert page.has_content?('Version 1 of 1')
-      # 'sign_in_count' is one of the columns
-      # that should not be displayed
-      assert page.has_no_content?('sign_in_count')
-      # Close the modal
-      within '.modal-header' do
-        click_button '×'
+      # TODO: The delegate user should be there already:
+      # page.assert_selector('#memberships-panel tbody tr', count: 1)
+      # Add a team member
+      within('#team_show_tabs') do
+        click_on 'Users'
       end
-    end
-    page.find('#version-index-details').click_link 'Return to Team'
+      click_on 'Edit team grants'
+      page.check("grants_users_#{users(:standard_user).id}_#{TeamRole.fetch(:mbis_applicant).id}")
+      find_button('Update Roles').click
 
-    # Edit Team details:
-    page.find('#team-details-panel').click_link 'Edit'
+      # The now the standard user should be there too:
+      page.assert_selector('#memberships-panel tbody tr', count: 1)
+      # Check that a Membership version has been created:
+      page.find('#team-details-panel').click_link 'Audit'
+      assert page.has_content?('Grant')
+      # First row is the header
+      assert page.has_selector?('table#version-table tr', count: 3)
+      page.find('#version-table').click_link('Details', match: :first)
+      within_modal do
+        assert page.has_content?('Version 1 of 1')
+        # 'sign_in_count' is one of the columns
+        # that should not be displayed
+        assert page.has_no_content?('sign_in_count')
+        # Close the modal
+        within '.modal-header' do
+          click_button '×'
+        end
+      end
+      page.find('#version-index-details').click_link 'Return to Team'
 
-    assert page.has_content?('Editing Team: Test Team')
-    fill_in 'team_notes', with: 'Change the notes about this team'
-    click_button 'Save'
+      # Edit Team details:
+      page.find('#team-details-panel').click_link 'Edit'
 
-    within('#team-details-panel') do
-      assert page.has_content?('Change the notes about this team')
-    end
+      assert page.has_content?('Editing Team: Test Team')
+      fill_in 'team_notes', with: 'Change the notes about this team'
+      click_button 'Save'
 
-    # Check that another version of Team has been created:
-    page.find('#team-details-panel').click_link 'Audit'
-    assert page.has_content?('update')
-    # First row is the header
-    assert page.has_selector?('table#version-table tr', count: 4)
+      within('#team-details-panel') do
+        assert page.has_content?('Change the notes about this team')
+      end
 
-    page.find('#version-table').click_link('Details', match: :first)
-    within_modal(remain: true) do
-      assert page.has_content?('Version 2 of 2')
-      assert page.has_content?('Change the notes about this team')
-      click_link 'Previous'
-      assert page.has_content?('Version 1 of 2')
-      assert page.has_content?('Some interesting notes about this project')
+      # Check that another version of Team has been created:
+      page.find('#team-details-panel').click_link 'Audit'
+      assert page.has_content?('update')
+      # First row is the header
+      assert page.has_selector?('table#version-table tr', count: 4)
+
+      page.find('#version-table').click_link('Details', match: :first)
+      within_modal(remain: true) do
+        assert page.has_content?('Version 2 of 2')
+        assert page.has_content?('Change the notes about this team')
+        click_link 'Previous'
+        assert page.has_content?('Version 1 of 2')
+        assert page.has_content?('Some interesting notes about this project')
+      end
     end
   end
 end

--- a/test/models/paper_trail/version_test.rb
+++ b/test/models/paper_trail/version_test.rb
@@ -1,66 +1,78 @@
 require 'test_helper'
 
-class VersionControllerTest < ActionDispatch::IntegrationTest
+class VersionTest < ActiveSupport::TestCase
   test 'versions of team are created when created or updated' do
-    team = create_team
-    assert_equal 1, team.versions.count
+    with_versioning do
+      team = create_team
+      assert_equal 1, team.versions.count
 
-    team.update(notes: 'These team notes have changed')
-    assert_equal 2, team.versions.count
-    expected_change = ['Test Team', 'These team notes have changed']
-    assert_equal expected_change, team.versions.last.changeset['notes']
+      team.update(notes: 'These team notes have changed')
+      assert_equal 2, team.versions.count
+      expected_change = ['Test Team', 'These team notes have changed']
+      assert_equal expected_change, team.versions.last.changeset['notes']
+    end
   end
 
   test 'versions of user are created when created or updated' do
-    user = create_user
-    assert_equal 1, user.versions.count
+    with_versioning do
+      user = create_user
+      assert_equal 1, user.versions.count
 
-    user.update(notes: 'These User notes have changed')
-    assert_equal 2, user.versions.count
-    expected_change = ['This is a test user', 'These User notes have changed']
-    assert_equal expected_change, user.versions.last.changeset['notes']
+      user.update(notes: 'These User notes have changed')
+      assert_equal 2, user.versions.count
+      expected_change = ['This is a test user', 'These User notes have changed']
+      assert_equal expected_change, user.versions.last.changeset['notes']
+    end
   end
 
   test 'versions of project are created when created or updated' do
-    project = create_project
-    # a second version is created when an association is added (team_data_source)
-    assert_equal 1, project.versions.count
+    with_versioning do
+      project = create_project
+      # a second version is created when an association is added (team_data_source)
+      assert_equal 1, project.versions.count
 
-    project.update(name: 'NCRS - Updated Project Name')
-    assert_equal 2, project.versions.count
-    expected_change = ['NCRS', 'NCRS - Updated Project Name']
-    assert_equal expected_change, project.versions.last.changeset['name']
+      project.update(name: 'NCRS - Updated Project Name')
+      assert_equal 2, project.versions.count
+      expected_change = ['NCRS', 'NCRS - Updated Project Name']
+      assert_equal expected_change, project.versions.last.changeset['name']
+    end
   end
 
   # 'application' => Project
   test 'project end use returned on as part of paper trail on a application' do
-    application = projects(:test_application)
-    assert_difference 'PaperTrail::Version.count', 1 do
-      application.end_uses << end_uses(:one)
-    end
+    with_versioning do
+      application = projects(:test_application)
+      assert_difference 'PaperTrail::Version.count', 1 do
+        application.end_uses << end_uses(:one)
+      end
 
-    assert_association_tracked(application, 'ProjectEndUse',
-                               application.project_end_uses.first.id)
+      assert_association_tracked(application, 'ProjectEndUse',
+                                 application.project_end_uses.first.id)
+    end
   end
 
   test 'project classification returned on as part of paper trail on a application' do
-    application = projects(:test_application)
-    assert_difference 'PaperTrail::Version.count', 1 do
-      application.classifications << classifications(:one)
-    end
+    with_versioning do
+      application = projects(:test_application)
+      assert_difference 'PaperTrail::Version.count', 1 do
+        application.classifications << classifications(:one)
+      end
 
-    assert_association_tracked(application, 'ProjectClassification',
-                               application.project_classifications.first.id)
+      assert_association_tracked(application, 'ProjectClassification',
+                                 application.project_classifications.first.id)
+    end
   end
 
   test 'project lawful basis returned on as part of paper trail on a application' do
-    application = projects(:test_application)
-    assert_difference 'PaperTrail::Version.count', 1 do
-      application.lawful_bases << Lookups::LawfulBasis.first
-    end
+    with_versioning do
+      application = projects(:test_application)
+      assert_difference 'PaperTrail::Version.count', 1 do
+        application.lawful_bases << Lookups::LawfulBasis.first
+      end
 
-    assert_association_tracked(application, 'ProjectLawfulBasis',
-                               application.project_lawful_bases.first.id)
+      assert_association_tracked(application, 'ProjectLawfulBasis',
+                                 application.project_lawful_bases.first.id)
+    end
   end
 
   private


### PR DESCRIPTION
## Summary

The `paper_trail` gem hooks into the ActiveRecord lifecycle and creates version entities after all CRUD operations through enabled models.

This includes in the test environment, where were generally don't care about auditing (with a few specific exceptions, where we're testing the ability to audit!)

This PR disables `paper_trail` in the test environment by default, and re-enables it for the specific tests that rely on audits being created.

## Measured outcome

This results in a significant performance improvement for the test suite.

### Before

```
Finished in 1183.671186s, 0.7198 runs/s, 3.9775 assertions/s.
852 runs, 4708 assertions, 0 failures, 0 errors, 13 skips
```

### After

```
Finished in 723.672889s, 1.1773 runs/s, 6.4864 assertions/s.
852 runs, 4708 assertions, 0 failures, 0 errors, 13 skips
```

This is roughly a 40% speed-up.