### PR TITLE
Target potential test flakiness source

### DIFF
--- a/test/integration/application_project_test.rb
+++ b/test/integration/application_project_test.rb
@@ -93,7 +93,7 @@ class ApplicationProjectTest < ActionDispatch::IntegrationTest
     sign_in @odr
     visit project_path(@project)
 
-    refute has_content? 'no contract document(s) attached'
+    assert has_no_content? 'no contract document(s) attached'
     assert has_button?  'Reject Contract'
     assert has_button?  'Mark Contract as Completed'
 
@@ -164,11 +164,11 @@ class ApplicationProjectTest < ActionDispatch::IntegrationTest
 
   test 'reset approvals should only show if user can reset approvals' do
     visit project_path(@project)
-    refute has_content? 'Reset Approvals'
+    assert has_no_content? 'Reset Approvals'
 
     @project.transition_to!(workflow_states(:submitted))
     visit project_path(@project)
-    refute has_content? 'Reset Approvals'
+    assert has_no_content? 'Reset Approvals'
 
     sign_in @odr
     visit project_path(@project)
@@ -183,7 +183,7 @@ class ApplicationProjectTest < ActionDispatch::IntegrationTest
     @project.transition_to!(workflow_states(:submitted))
     visit project_path(@project)
     click_on 'Users'
-    refute has_content? 'Edit'
+    assert has_no_content? 'Edit'
   end
 
   test 'should not be able to add or remove data items if the project is submitted' do
@@ -194,7 +194,7 @@ class ApplicationProjectTest < ActionDispatch::IntegrationTest
     @project.transition_to!(workflow_states(:submitted))
     visit project_path(@project)
     click_on 'Data Items'
-    refute has_content? 'Add / Remove data items'
+    assert has_no_content? 'Add / Remove data items'
   end
 
   test 'should only approve legal / ethical when project is submitted' do
@@ -203,7 +203,7 @@ class ApplicationProjectTest < ActionDispatch::IntegrationTest
     visit project_path(project)
     click_on 'Legal / Ethical'
     assert has_content? 'Edit'
-    refute has_content? 'Approve'
+    assert has_no_content? 'Approve'
 
     project.transition_to!(workflow_states(:review))
     project.transition_to!(workflow_states(:submitted))
@@ -211,7 +211,7 @@ class ApplicationProjectTest < ActionDispatch::IntegrationTest
     sign_in @odr
     visit project_path(project)
     click_on 'Legal / Ethical'
-    refute has_content? 'Edit'
+    assert has_no_content? 'Edit'
     assert has_content? 'Approve'
   end
 

--- a/test/integration/contracts_test.rb
+++ b/test/integration/contracts_test.rb
@@ -20,7 +20,7 @@ class ContractsTest < ActionDispatch::IntegrationTest
     within(dom_id) do
       assert has_link?(href: contract_path(contract),      title: 'Details')
       assert has_link?(href: edit_contract_path(contract), title: 'Edit')
-      refute has_link?(href: contract_path(contract),      title: 'Delete')
+      assert has_no_link?(href: contract_path(contract),   title: 'Delete')
     end
   end
 

--- a/test/integration/data_privacy_impact_assessments_test.rb
+++ b/test/integration/data_privacy_impact_assessments_test.rb
@@ -14,13 +14,13 @@ class DataPrivacyImpactAssessmentsTest < ActionDispatch::IntegrationTest
 
     dom_id = "\#data_privacy_impact_assessment_#{dpia.id}"
 
-    refute has_link?(href: new_project_data_privacy_impact_assessment_path(project))
+    assert has_no_link?(href: new_project_data_privacy_impact_assessment_path(project))
     assert has_selector?(dom_id)
 
     within(dom_id) do
-      assert has_link?(href: data_privacy_impact_assessment_path(dpia),      title: 'Details')
-      refute has_link?(href: edit_data_privacy_impact_assessment_path(dpia), title: 'Edit')
-      refute has_link?(href: data_privacy_impact_assessment_path(dpia),      title: 'Delete')
+      assert has_link?(href: data_privacy_impact_assessment_path(dpia),         title: 'Details')
+      assert has_no_link?(href: edit_data_privacy_impact_assessment_path(dpia), title: 'Edit')
+      assert has_no_link?(href: data_privacy_impact_assessment_path(dpia),      title: 'Delete')
     end
   end
 

--- a/test/integration/organisations_flow_test.rb
+++ b/test/integration/organisations_flow_test.rb
@@ -115,7 +115,7 @@ class OrganisationsFlowsTest < ActionDispatch::IntegrationTest
 
     within('table') do
       assert has_text?('Test Organisation One')
-      refute has_text?('Test Organisation Two')
+      assert has_no_text?('Test Organisation Two')
     end
   end
 end

--- a/test/integration/project_amendments_test.rb
+++ b/test/integration/project_amendments_test.rb
@@ -15,14 +15,14 @@ class ProjectAmendmentsTest < ActionDispatch::IntegrationTest
     within('#projectAmendments') do
       dom_id = "\#project_amendment_#{amendment.id}"
 
-      refute has_link?(href: new_project_project_amendment_path(project))
+      assert has_no_link?(href: new_project_project_amendment_path(project))
       assert has_selector?(dom_id)
 
       within(dom_id) do
         assert has_text?(amendment.requested_at.to_s(:ui))
-        assert has_link?(href: project_amendment_path(amendment),      title: 'Details')
-        refute has_link?(href: edit_project_amendment_path(amendment), title: 'Edit')
-        refute has_link?(href: project_amendment_path(amendment),      title: 'Delete')
+        assert has_link?(href: project_amendment_path(amendment),         title: 'Details')
+        assert has_no_link?(href: edit_project_amendment_path(amendment), title: 'Edit')
+        assert has_no_link?(href: project_amendment_path(amendment),      title: 'Delete')
       end
     end
   end

--- a/test/integration/project_core_test.rb
+++ b/test/integration/project_core_test.rb
@@ -170,8 +170,8 @@ class ProjectCoreTest < ActionDispatch::IntegrationTest
     visit team_path(teams(:team_two))
 
     assert_equal team_path(teams(:team_two)), current_path
-    refute has_button? 'Import'
-    refute has_field? 'file'
+    assert has_no_button? 'Import'
+    assert has_no_field? 'file'
   end
 
   test 'should be able to import application PDF forms as an :application_manager role' do

--- a/test/integration/workflow_test.rb
+++ b/test/integration/workflow_test.rb
@@ -47,7 +47,7 @@ class WorkflowTest < ActionDispatch::IntegrationTest
         click_button 'Approve'
       end
 
-      refute has_text? 'Authentication Required'
+      assert has_no_text? 'Authentication Required'
     end
   end
 end


### PR DESCRIPTION
This PR avoids using `refute` with the _positive_ version of Capybara matchers, instead using `assert` with the negative versions - i.e.

```diff
- refute has_content?('Some text')
+ assert has_no_content?('Some text')
```

The former can flake due to how Capybara's wait mechanics work, whereas the latter instructs capybara that the "accept criteria" is for content to _not_ be present.

