### PR TITLE
Tag mammoth end-to-end tests as flakey

### DIFF
--- a/test/integration/create_eoi_project_test.rb
+++ b/test/integration/create_eoi_project_test.rb
@@ -8,7 +8,7 @@ class CreateEoiProjectTest < ActionDispatch::IntegrationTest
     login_and_accept_terms(@user)
   end
 
-  test 'create eoi' do
+  flakey_test 'create eoi' do
     visit team_path(@team)
     click_button 'New'
     click_link 'EOI'

--- a/test/integration/create_mbis_project_test.rb
+++ b/test/integration/create_mbis_project_test.rb
@@ -8,7 +8,7 @@ class CreateMbisProjectTest < ActionDispatch::IntegrationTest
     login_and_accept_terms(@user)
   end
 
-  test 'create project test' do
+  flakey_test 'create project test' do
     visit team_path(@team)
     click_button 'New'
     click_link 'Project'


### PR DESCRIPTION
## Summary

There are a couple of integration tests in particular that seem to flake on a regular basis on CI, which is disruptive for others.

This PR uses ndr_dev_support's [`flakey_test`](https://github.com/publichealthengland/ndr_dev_support#flakey-tests) add-on to try and manage this; they'll get three attempts to pass before failing the build.

This is a sticking plaster; we should still try to understand what's going on with these.