### PR TITLE
# Limit fuzzy matching of non-cancer deaths to within 14 years, resolves #25644

### DIFF
--- a/lib/tasks/export_matched.rake
+++ b/lib/tasks/export_matched.rake
@@ -8,6 +8,7 @@ namespace :export do
 Export matched MBIS data (matching by exact NHS number and date of birth)
 Syntax: rake export:matched [infile=demog.csv] [outfile=creg_data.ncr] \\
         e_type=PSDEATH klass=Export::CancerDeathWeekly [verbose=true] [allow_fuzzy=true]
+allow_fuzzy options: true / veryfuzzy / fuzzy / false
 infile (or stdin) is a CSV of rowid,nhsnumber,birthdate,postcode
 e.g.: 12345,9999999468,1925-01-27,B6 5RQ
 EOT
@@ -28,7 +29,12 @@ Enter CSV data, ^D to finish. For syntax: rake -D match:demographics
     raise 'Expected parameter e_type' unless e_type
     key_names = ENV['key_names'] ? ENV['key_names'].split(',') : nil
     logger = ENV['verbose'] ? ActiveSupport::Logger.new($stdout) : nil
-    match_scores = ENV['allow_fuzzy'] == 'true' ? [:perfect, :fuzzy] : [:perfect]
+    match_scores = case ENV['allow_fuzzy']
+                   when 'true', 'veryfuzzy'; [:veryfuzzy, :perfect, :fuzzy]
+                   when 'fuzzy'; [:perfect, :fuzzy]
+                   when 'false', nil; [:perfect]
+                   else raise 'Invalid allow_fuzzy parameter value'
+                   end
     klass = ENV['klass'].constantize # e.g. Export::DelimitedFile, Export::CancerMortalityFile
     matches = Pseudo::Match::Ppatients.new([e_type], key_names, logger).
               match(infile, match_scores) # list of [pseudo_id1, rowid, ppatientid, match_status]

--- a/test/models/pseudo/death_test.rb
+++ b/test/models/pseudo/death_test.rb
@@ -7,7 +7,7 @@ module Pseudo
     setup do
       # Sample demographics, that will produce pseudo_id1 and pseudo_id2 values
       @nhsnumber = '9999999468'
-      @birthdate = '1925-01-27'
+      @birthdate = '1925-01-27' # More than 14 years from @birthdate2, i.e. :veryfuzzy match
       @postcode = 'PE133AB'
       @demographics = { 'nhsnumber' => @nhsnumber, 'birthdate' => @birthdate,
                         'postcode' => @postcode }
@@ -21,6 +21,7 @@ module Pseudo
       @postcode2 = 'OX4 2GX' # Spaces will be stripped in generating pseudo_id2
       @demographics2 = { 'nhsnumber' => @nhsnumber2, 'birthdate' => @birthdate2,
                          'postcode' => @postcode2 }
+      @birthdate3 = '1963-01-01' # Less than 14 years from @birthdate2, i.e. :fuzzy match
     end
 
     test 'create_from_demographics without rawtext' do
@@ -87,7 +88,8 @@ module Pseudo
                               e_batch: @e_batch)
       ppat.save!
       assert_equal(:new, ppat.match_demographics(@nhsnumber, '', @birthdate))
-      assert_equal(:fuzzy, ppat.match_demographics(@nhsnumber2, '', @birthdate))
+      assert_equal(:veryfuzzy, ppat.match_demographics(@nhsnumber2, '', @birthdate))
+      assert_equal(:fuzzy, ppat.match_demographics(@nhsnumber2, '', @birthdate3))
       assert_equal(:perfect, ppat.match_demographics(@nhsnumber2, '', @birthdate2))
       # We can unlock it with blank demographics
       assert(ppat.unlock_demographics('', '', '', :match))

--- a/test/models/pseudo/prescription_test.rb
+++ b/test/models/pseudo/prescription_test.rb
@@ -6,7 +6,7 @@ module Pseudo
   class PrescriptionTest < ActiveSupport::TestCase
     setup do
       @nhsnumber = '9999999468'
-      @birthdate = '1925-01-27'
+      @birthdate = '1925-01-27' # More than 14 years from @birthdate2, i.e. :veryfuzzy match
       @demographics = { 'nhsnumber' => @nhsnumber, 'birthdate' => @birthdate }
       @key = 'unittest_pseudo_prescr'
       ENV['MBIS_KEK'] = 'test'
@@ -16,6 +16,7 @@ module Pseudo
       @nhsnumber2 = '9999999476'
       @birthdate2 = '1964-02-29'
       @demographics2 = { 'nhsnumber' => @nhsnumber2, 'birthdate' => @birthdate2 }
+      @birthdate3 = '1963-01-01' # Less than 14 years from @birthdate2, i.e. :fuzzy match
     end
 
     test 'create_from_demographics without rawtext' do
@@ -66,7 +67,8 @@ module Pseudo
                               e_batch: @e_batch)
       ppat.save!
       assert_equal(:new, ppat.match_demographics(@nhsnumber, '', @birthdate))
-      assert_equal(:fuzzy, ppat.match_demographics(@nhsnumber2, '', @birthdate))
+      assert_equal(:veryfuzzy, ppat.match_demographics(@nhsnumber2, '', @birthdate))
+      assert_equal(:fuzzy, ppat.match_demographics(@nhsnumber2, '', @birthdate3))
       assert_equal(:perfect, ppat.match_demographics(@nhsnumber2, '', @birthdate2))
       assert_not(ppat.unlock_demographics(@nhsnumber, '', @birthdate, :match))
       assert(ppat.unlock_demographics(@nhsnumber2, '', @birthdate2, :match))


### PR DESCRIPTION
# rake export:matched now accepts allow_fuzzy={fuzzy,veryfuzzy,perfect}