### PR TITLE
Simplify node category editing

### DIFF
--- a/app/controllers/node_categories_controller.rb
+++ b/app/controllers/node_categories_controller.rb
@@ -17,15 +17,12 @@ class NodeCategoriesController < NodesController
 
   def update
     if perform_authorized_node_category_updates!(node_category_matrix)
-      respond_to do |format|
-        format.html { redirect_to @node.dataset_version, notice: message }
-        format.js
-        flash[:notice] = 'Node categories updated.'
-      end
+      flash[:notice] = 'Node categories updated.'
     else
-      flash.now[:alert] = 'Cannot remove all node_categories!'
-      redirect_to @node.dataset_version
+      flash[:alert] = 'Cannot remove all node_categories!'
     end
+
+    redirect_to @node.dataset_version
   end
 
   def authorize_user_for_editing

--- a/app/views/node_categories/update.js
+++ b/app/views/node_categories/update.js
@@ -1,2 +1,0 @@
-jQuery('#node-categories').click()
-

--- a/app/views/nodes/_node_categories.html.erb
+++ b/app/views/nodes/_node_categories.html.erb
@@ -4,7 +4,7 @@
   View/Manage Node Categories
 </button>
 <% url = node_node_categories_path(node) %>
-<%= form_tag(url, method: :patch, remote: true) %>
+<%= form_tag(url, method: :patch) %>
   <div class="collapse" id="node-categories-form">
     <div class="card card-body">
       <table class="table table-hover">

--- a/test/integration/can_manage_node_categories_test.rb
+++ b/test/integration/can_manage_node_categories_test.rb
@@ -49,7 +49,16 @@ class CanManageNodeCategoriesTest < ActionDispatch::IntegrationTest
       check "node_categories_#{dataset_version.categories.find_by(name: 'Tabby Cat').id}"
       check "node_categories_#{dataset_version.categories.find_by(name: 'Hell Cat').id}"
       click_on 'Update Node Categories'
-      assert_no_text 'Tabby Cat'
+      assert_text 'Node categories updated.'
+    end
+
+    assert_no_difference('NodeCategory.count') do
+      click_on 'View/Manage Node Categories'
+      assert_text 'Tabby Cat'
+      uncheck "node_categories_#{dataset_version.categories.find_by(name: 'Tabby Cat').id}"
+      uncheck "node_categories_#{dataset_version.categories.find_by(name: 'Hell Cat').id}"
+      click_on 'Update Node Categories'
+      assert_text 'Cannot remove all node_categories'
     end
   end
 end


### PR DESCRIPTION
This PR removes partially-working JS handling, and stick to HTML requests. It ensures that the guards against removing all categories is working, and tested.

This integration test seemed very flakey with the latest gems (50%+ failure rate, for reasons I'm not 100% sure about) - but this simpler approach has passed 100x in a row for me locally.