### PR TITLE
Germline importers qa

### DIFF
--- a/lib/import/brca/providers/birmingham/birmingham_handler.rb
+++ b/lib/import/brca/providers/birmingham/birmingham_handler.rb
@@ -66,7 +66,12 @@ module Import
             process_impact(genotype, record)
             process_genomic_change(genotype, record)
             process_test_scope_and_type(genotype, record)
+            add_organisationcode_testresult(genotype)
             @persister.integrate_and_store(genotype)
+          end
+
+          def add_organisationcode_testresult(genotype)
+            genotype.attribute_map['organisationcode_testresult'] = '699F0'
           end
 
           # TODO: this same parser occurs in Cambridge as well - should find a nice

--- a/lib/import/brca/providers/bristol/bristol_handler.rb
+++ b/lib/import/brca/providers/bristol/bristol_handler.rb
@@ -24,7 +24,12 @@ module Import
             add_simple_fields(genotype, record)
             process_cdna_change(genotype, record)
             add_protein_impact(genotype, record)
+            add_organisationcode_testresult(genotype)
             @persister.integrate_and_store(genotype)
+          end
+
+          def add_organisationcode_testresult(genotype)
+            genotype.attribute_map['organisationcode_testresult'] = '698V0'
           end
 
           def add_simple_fields(genotype, record)

--- a/lib/import/brca/providers/cambridge/cambridge_handler.rb
+++ b/lib/import/brca/providers/cambridge/cambridge_handler.rb
@@ -43,7 +43,12 @@ module Import
             genotype.add_method('ngs')
             add_zygosity(genotype, record)
             process_exons(record.raw_fields['proteinimpact'], genotype)
+            add_organisationcode_testresult(genotype)
             @persister.integrate_and_store(genotype)
+          end
+
+          def add_organisationcode_testresult(genotype)
+            genotype.attribute_map['organisationcode_testresult'] = '69860'
           end
 
           def process_cdna_change(genotype, record)

--- a/lib/import/brca/providers/leeds/leeds_handler.rb
+++ b/lib/import/brca/providers/leeds/leeds_handler.rb
@@ -136,7 +136,7 @@ module Import
             add_gene_cdna_protein_from_report(genotype, record) # Added by Francesco
             add_scope_and_type_from_genotype(genotype, record) # Added by Francesco
             add_b1_b2_c3_pos(genotype, record) # Added by Francesco ad hoc
-
+            add_organisationcode_testresult(genotype)
             genotype.add_provider_name(record.raw_fields['reffac.name'])
             sample_type = record.raw_fields['sampletype']
             genotype.add_specimen_type(sample_type) unless sample_type.nil?
@@ -153,6 +153,10 @@ module Import
             process_scope(geno, genotype, record)
             res = @extractor.process(geno, report, genotype)
             res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
+          end
+
+          def add_organisationcode_testresult(genotype)
+            genotype.attribute_map['organisationcode_testresult'] = '699C0'
           end
 
           def add_BRCA_from_raw_genotype(genotype, record)

--- a/lib/import/brca/providers/london_kgc/london_kgc_handler.rb
+++ b/lib/import/brca/providers/london_kgc/london_kgc_handler.rb
@@ -33,9 +33,14 @@ module Import
             #process_cdna_change(genotype, record)
             process_varpathclass(genotype, record)
             process_exons(genotype, record)
+            add_organisationcode_testresult(genotype)
             res = process_gene(genotype, record)
             res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
             # @persister.integrate_and_store(genotype)
+          end
+
+          def add_organisationcode_testresult(genotype)
+            genotype.attribute_map['organisationcode_testresult'] = '697Q0'
           end
 
           def process_single_cdna_change(genotype, record)

--- a/lib/import/brca/providers/manchester/manchester_handler.rb
+++ b/lib/import/brca/providers/manchester/manchester_handler.rb
@@ -42,10 +42,15 @@ module Manchester
                                       record.raw_fields,
                                       PASS_THROUGH_FIELDS)
       # @persister.integrate_and_store(genotype)
-      genotype.add_test_scope(:full_screen)
-      genotype.add_molecular_testing_type_strict(:predictive)
+      # genotype.add_test_scope(:full_screen)
+      # genotype.add_molecular_testing_type_strict(:predictive)
+      add_organisationcode_testresult(genotype)
       final_genotypes = process_raw_genotype(genotype, record)
       final_genotypes.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
+    end
+
+    def add_organisationcode_testresult(genotype)
+      genotype.attribute_map['organisationcode_testresult'] = '69820'
     end
 
     def process_raw_genotype(genotype, record)

--- a/lib/import/brca/providers/newcastle/newcastle_handler.rb
+++ b/lib/import/brca/providers/newcastle/newcastle_handler.rb
@@ -93,36 +93,14 @@ module Import
             add_brca_from_raw_genotype(genotype, record) # Added by Francesco
             add_cdna_change_from_report(genotype, record) # Added by Francesco
             process_protein_impact(genotype, record) # Added by Francesco
+            add_organisationcode_testresult(genotype)
             final_results = process_raw_genotype(genotype, record)
             final_results.map { |x| @persister.integrate_and_store(x) }
           end
 
-          # def process_investigation_code(genotype, record)
-          #   raw_code = Maybe(record.raw_fields['investigationcode']).
-          #              or_else(Maybe(record.raw_fields['moleculartestingtype'])).
-          #              or_else(Maybe(record.raw_fields['service category'])).
-          #              or_else(Maybe(record.raw_fields['referralreason'])
-          #   puts
-          #   case raw_code
-          #   when String
-          #     inv_code = 'o'
-          #     scope = TEST_SCOPE_MAP[raw_code.downcase.strip]
-          #     scope2 = TEST_SCOPE_FROM_TYPE_MAP[raw_code.downcase.strip]
-          #     if inv_code
-          #       dd_scope_from_service_category(record.raw_fields['service category'], genotype)
-          #     elsif scope
-          #       genotype.add_test_scope(scope)
-          #     elsif scope2
-          #       @logger.info "SUCA"
-          #       process_scope_from_type(genotype,record)
-          #     else
-          #       puts 'CAZZI'
-          #       #add_scope_from_service_category(record.raw_fields['service category'], genotype)
-          #     end
-          #   when Nil
-          #     add_scope_from_service_category(record.raw_fields['service category'], genotype)
-          #   end
-          # end
+          def add_organisationcode_testresult(genotype)
+            genotype.attribute_map['organisationcode_testresult'] = '699A0'
+          end
 
           def process_investigation_code(genotype, record)
             if record.raw_fields['service category'].to_s.downcase.strip == 'o'

--- a/lib/import/brca/providers/nottingham/nottingham_handler.rb
+++ b/lib/import/brca/providers/nottingham/nottingham_handler.rb
@@ -45,8 +45,13 @@ module Import
             process_gene(genotype, record) # Added by Francesco
             process_cdna_change(genotype, record)
             process_varpathclass(genotype, record)
+            add_organisationcode_testresult(genotype)
             extract_teststatus(genotype, record) # added by Francesco
             @persister.integrate_and_store(genotype)
+          end
+
+          def add_organisationcode_testresult(genotype)
+            genotype.attribute_map['organisationcode_testresult'] = '698A0'
           end
 
           def add_simple_fields(genotype, record)

--- a/lib/import/brca/providers/oxford/oxford_handler.rb
+++ b/lib/import/brca/providers/oxford/oxford_handler.rb
@@ -38,8 +38,13 @@ module Import
             process_protein_impact(genotype, record)
             assign_genomic_change(genotype, record)
             assign_servicereportidentifier(genotype, record)
+            add_organisationcode_testresult(genotype)
             res = process_gene(genotype, record)
             res&.each { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
+          end
+
+          def add_organisationcode_testresult(genotype)
+            genotype.attribute_map['organisationcode_testresult'] = '698C0'
           end
 
           def assign_method(genotype, record)

--- a/lib/import/brca/providers/royal_marsden/royal_marsden_handler.rb
+++ b/lib/import/brca/providers/royal_marsden/royal_marsden_handler.rb
@@ -28,8 +28,13 @@ module RoyalMarsden
                                       record.raw_fields,
                                       PASS_THROUGH_FIELDS)
       process_cdna_change(genotype, record)
+      add_organisationcode_testresult(genotype)
       process_gene(genotype, record)
       @persister.integrate_and_store(genotype)
+    end
+
+    def add_organisationcode_testresult(genotype)
+      genotype.attribute_map['organisationcode_testresult'] = '696L0'
     end
 
     def process_cdna_change(genotype, record)

--- a/lib/import/brca/providers/salisbury/salisbury_handler_deprecated.rb
+++ b/lib/import/brca/providers/salisbury/salisbury_handler_deprecated.rb
@@ -50,12 +50,17 @@ module Salisbury
         genotype.add_test_scope(scope) if scope
       end
       extract_teststatus(genotype, record)
+      add_organisationcode_testresult(genotype)
       genotype.add_specimen_type(record.mapped_fields['specimentype'])
       genotype.add_received_date(record.raw_fields['date of receipt'])
       genotype.add_passthrough_fields(record.mapped_fields,
                                       record.raw_fields,
                                       PASS_THROUGH_FIELDS)
       @persister.integrate_and_store(genotype)
+    end
+
+    def add_organisationcode_testresult(genotype)
+      genotype.attribute_map['organisationcode_testresult'] = '699H0'
     end
 
     def extract_gene(test_string, genotype)

--- a/lib/import/brca/providers/sheffield/sheffield_handler.rb
+++ b/lib/import/brca/providers/sheffield/sheffield_handler.rb
@@ -71,10 +71,15 @@ module Import
             add_test_scope_from_karyo(genotype, record)
             process_exons(record.raw_fields['genotype'], genotype)
             process_gene_from_column(genotype, record) # Just added
+            add_organisationcode_testresult(genotype)
             res = process_gene(genotype, record)
             res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
 
             # @lines_processed += 1 # TODO: factor this out to be automatic across handlers
+          end
+
+          def add_organisationcode_testresult(genotype)
+            genotype.attribute_map['organisationcode_testresult'] = '699D0'
           end
 
           def add_test_scope(genotype, record)

--- a/lib/import/brca/providers/st_george/st_george_handler.rb
+++ b/lib/import/brca/providers/st_george/st_george_handler.rb
@@ -23,8 +23,13 @@ module StGeorge
       genotype.add_passthrough_fields(record.mapped_fields,
                                       record.raw_fields,
                                       PASS_THROUGH_FIELDS)
+      add_organisationcode_testresult(genotype)
       process_cdna_change(genotype, record)
       @persister.integrate_and_store(genotype)
+    end
+
+    def add_organisationcode_testresult(genotype)
+      genotype.attribute_map['organisationcode_testresult'] = '697N0'
     end
 
     def process_cdna_change(genotype, record)

--- a/lib/import/brca/providers/st_thomas/st_thomas_handler.rb
+++ b/lib/import/brca/providers/st_thomas/st_thomas_handler.rb
@@ -17,8 +17,12 @@ module StThomas
                                       PASS_THROUGH_FIELDS)
       mtype = record.raw_fields['moleculartestingtype']
       genotype.add_molecular_testing_type_strict(mtype) if mtype
-
+      add_organisationcode_testresult(genotype)
       @persister.integrate_and_store(genotype)
+    end
+
+    def add_organisationcode_testresult(genotype)
+      genotype.attribute_map['organisationcode_testresult'] = '699L0'
     end
 
     # use the raw:predictive test performed overall, but check that full screen result is null

--- a/lib/import/colorectal/providers/birmingham/birmingham_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/birmingham/birmingham_handler_colorectal.rb
@@ -26,6 +26,7 @@ module Import
                                                   record.raw_fields,
                                                   PASS_THROUGH_FIELDS_COLO)
             process_genetictestscope(genocolorectal, record)
+            add_organisationcode_testresult(genocolorectal)
             variant_processor = VariantProcessor.new(genocolorectal, record, @logger)
             res = variant_processor.process_variants_from_report
             res.each { |cur_genotype| @persister.integrate_and_store(cur_genotype) }

--- a/lib/import/colorectal/providers/cambridge/cambridge_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/cambridge/cambridge_handler_colorectal.rb
@@ -40,8 +40,13 @@ module Import
             genocolorectal.add_test_scope(:full_screen)
             genocolorectal.add_method('ngs')
             add_zygosity(genocolorectal, record)
+            add_organisationcode_testresult(genocolorectal)
             process_exons(record.raw_fields['proteinimpact'], genocolorectal)
             @persister.integrate_and_store(genocolorectal)
+          end
+
+          def add_organisationcode_testresult(genocolorectal)
+            genocolorectal.attribute_map['organisationcode_testresult'] = '69860'
           end
 
           def process_cdna_change(genocolorectal, record)

--- a/lib/import/colorectal/providers/leeds/leeds_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/leeds/leeds_handler_colorectal.rb
@@ -176,8 +176,13 @@ module Import
             add_positive_teststatus(genocolorectal, record)
             failed_teststatus(genocolorectal, record)
             add_benign_varclass(genocolorectal, record)
+            add_organisationcode_testresult(genocolorectal)
             res = add_gene_from_report(genocolorectal, record) # Added by Francesco
             res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
+          end
+
+          def add_organisationcode_testresult(genocolorectal)
+            genocolorectal.attribute_map['organisationcode_testresult'] = '699C0'
           end
 
           def add_positive_teststatus(genocolorectal, record)

--- a/lib/import/colorectal/providers/leeds/leeds_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/leeds/leeds_handler_colorectal.rb
@@ -525,7 +525,7 @@ module Import
                   @logger.debug "SUCCESSFUL protein impact parse for: #{$LAST_MATCH_INFO[:impact]}"
                   @logger.debug "FOUND ABSENT VARIANT FOR : #{rawreport}"
                   genotypes << genocolorectal
-                elsif genetictestscope == 'Targeted Colorectal mutation test'
+                elsif genetictestscope == 'Targeted Colorectal Lynch or MMR'
                   genocolorectal.add_gene_colorectal($LAST_MATCH_INFO[:genes])
                   genocolorectal.add_protein_impact(nil)
                   genocolorectal.add_gene_location(nil)
@@ -574,7 +574,7 @@ module Import
                   genocolorectal.add_variant_type(rawreport)
                   genocolorectal.add_status(1)
                   genotypes.append(genocolorectal)
-                elsif genetictestscope == 'Targeted Colorectal mutation test'
+                elsif genetictestscope == 'Targeted Colorectal Lynch or MMR'
                   genocolorectal.add_gene_colorectal(COLORECTAL_GENES_REGEX.match(rawreport)[0])
                   genocolorectal.add_exon_location(nil)
                   genocolorectal.add_variant_type(nil)
@@ -590,7 +590,7 @@ module Import
                   genocolorectal.add_variant_type(rawreport)
                   genocolorectal.add_status(1)
                   genotypes.append(genocolorectal)
-                elsif genetictestscope == 'Targeted Colorectal mutation test'
+                elsif genetictestscope == 'Targeted Colorectal Lynch or MMR'
                   genocolorectal.add_gene_colorectal(COLORECTAL_GENES_REGEX.match(rawreport)[0])
                   genocolorectal.add_exon_location(nil)
                   genocolorectal.add_variant_type(nil)

--- a/lib/import/colorectal/providers/london_gosh/london_gosh_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/london_gosh/london_gosh_handler_colorectal.rb
@@ -67,10 +67,15 @@ module Import
                                                   PASS_THROUGH_FIELDS_COLO)
             genocolorectal.add_test_scope(:full_screen)
             process_varpathclass(genocolorectal, record)
+            add_organisationcode_testresult(genocolorectal)
             # process_gene_and_variant(genocolorectal, record)
             res = process_gene_and_variant(genocolorectal, record)
             res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
             # @persister.integrate_and_store(genocolorectal)
+          end
+
+          def add_organisationcode_testresult(genocolorectal)
+            genocolorectal.attribute_map['organisationcode_testresult'] = '69A70'
           end
 
           def process_gene_and_variant(genocolorectal, record)

--- a/lib/import/colorectal/providers/london_kgc/london_kgc_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/london_kgc/london_kgc_handler_colorectal.rb
@@ -38,8 +38,13 @@ module Import
                                                   record.raw_fields,
                                                   PASS_THROUGH_FIELDS_COLO)
             genocolorectal.add_test_scope(:full_screen)
+            add_organisationcode_testresult(genocolorectal)
             res = extract_lynch_from_record(genocolorectal, record)
             res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
+          end
+
+          def add_organisationcode_testresult(genocolorectal)
+            genocolorectal.attribute_map['organisationcode_testresult'] = '697Q0'
           end
 
           def extract_lynch_from_record(genocolorectal, record)

--- a/lib/import/colorectal/providers/newcastle/newcastle_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/newcastle/newcastle_handler_colorectal.rb
@@ -107,9 +107,14 @@ module Import
             identifier = record.raw_fields['ngs sample number']
             genocolorectal.add_servicereportidentifier(identifier) unless identifier.nil?
             process_test_type(genocolorectal, record)
+            add_organisationcode_testresult(genocolorectal)
             process_investigation_code(genocolorectal, record)
             res = process_gene_colorectal(genocolorectal, record) # Added by Francesco
             res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
+          end
+
+          def add_organisationcode_testresult(genocolorectal)
+            genocolorectal.attribute_map['organisationcode_testresult'] = '699A0'
           end
 
           def process_investigation_code(genocolorectal, record)

--- a/lib/import/colorectal/providers/nottingham/nottingham_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/nottingham/nottingham_handler_colorectal.rb
@@ -78,7 +78,12 @@ module Import
             process_gene_colorectal(genotype, record) # Added by Francesco
             extract_variantclass_from_genotype(genotype, record) # Added by Francesco
             extract_teststatus(genotype, record) # added by Francesco
+            add_organisationcode_testresult(genotype)
             @persister.integrate_and_store(genotype)
+          end
+
+          def add_organisationcode_testresult(genotype)
+            genotype.attribute_map['organisationcode_testresult'] = '698A0'
           end
 
           def add_test_type(genotype, record)

--- a/lib/import/colorectal/providers/oxford/oxford_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/oxford/oxford_handler_colorectal.rb
@@ -59,8 +59,13 @@ module Import
             assign_genomic_change(genocolorectal, record)
             assign_servicereportidentifier(genocolorectal, record)
             assign_variantpathclass(genocolorectal, record)
+            add_organisationcode_testresult(genocolorectal)
             res = process_records(genocolorectal, record)
             res.each { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
+          end
+
+          def add_organisationcode_testresult(genocolorectal)
+            genocolorectal.attribute_map['organisationcode_testresult'] = '698C0'
           end
 
           def assign_method(genocolorectal, record)

--- a/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
@@ -65,7 +65,6 @@ module Import
             genocolorectal.add_passthrough_fields(record.mapped_fields,
                                                   record.raw_fields,
                                                   PASS_THROUGH_FIELDS_COLO)
-            # process_gene(genocolorectal, record)
             process_varpathclass(genocolorectal, record)
             process_teststatus(genocolorectal, record)
             process_variant(genocolorectal, record)
@@ -73,23 +72,14 @@ module Import
             process_test_scope(genocolorectal, record)
             process_test_type(genocolorectal, record)
             add_organisationcode_testresult(genocolorectal)
-            # @persister.integrate_and_store(genocolorectal)
             res = process_gene(genocolorectal, record)# Added by Francesco
             res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
           end
 
-          # def process_gene(genocolorectal, record)
-          #   genes = record.raw_fields['gene']
-          #   if COLORECTAL_GENES_REGEX.match(genes)
-          #     genocolorectal.add_gene_colorectal($LAST_MATCH_INFO[:colorectal])
-          #     @successful_gene_counter += 1
-          #   end
-          # end
-
           def add_organisationcode_testresult(genocolorectal)
             genocolorectal.attribute_map['organisationcode_testresult'] = '696L0'
           end
-          
+
           def process_gene(genocolorectal, record)
             genotypes = []
             genes = record.raw_fields['gene']

--- a/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
@@ -63,24 +63,38 @@ module Import
             genocolorectal.add_passthrough_fields(record.mapped_fields,
                                                   record.raw_fields,
                                                   PASS_THROUGH_FIELDS_COLO)
-            process_gene(genocolorectal, record)
+            # process_gene(genocolorectal, record)
             process_varpathclass(genocolorectal, record)
             process_teststatus(genocolorectal, record)
             process_variant(genocolorectal, record)
             process_large_deldup(genocolorectal, record)
             process_test_scope(genocolorectal, record)
             process_test_type(genocolorectal, record)
-            @persister.integrate_and_store(genocolorectal)
+            # @persister.integrate_and_store(genocolorectal)
+            res = process_gene(genocolorectal, record)# Added by Francesco
+            res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
           end
 
+          # def process_gene(genocolorectal, record)
+          #   genes = record.raw_fields['gene']
+          #   if COLORECTAL_GENES_REGEX.match(genes)
+          #     genocolorectal.add_gene_colorectal($LAST_MATCH_INFO[:colorectal])
+          #     @successful_gene_counter += 1
+          #   end
+          # end
+
           def process_gene(genocolorectal, record)
+            genotypes = []
             genes = record.raw_fields['gene']
             if COLORECTAL_GENES_REGEX.match(genes)
               genocolorectal.add_gene_colorectal($LAST_MATCH_INFO[:colorectal])
               @successful_gene_counter += 1
+              genotypes.append(genocolorectal)
+            else @logger.debug 'NOT A COLORECTAL/LYNCH/MMR RECORD'
             end
+            genotypes
           end
-
+          
           def process_varpathclass(genocolorectal, record)
             varpathclass = record.raw_fields['variantpathclass'].downcase.strip unless record.raw_fields['variantpathclass'].nil?
 

--- a/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal.rb
@@ -13,6 +13,8 @@ module Import
                                         authoriseddate requesteddate practitionercode genomicchange
                                         specimentype].freeze
 
+
+                                        
           COLORECTAL_GENES_REGEX = /(?<colorectal>APC|
                                                 BMPR1A|
                                                 EPCAM|
@@ -70,6 +72,7 @@ module Import
             process_large_deldup(genocolorectal, record)
             process_test_scope(genocolorectal, record)
             process_test_type(genocolorectal, record)
+            add_organisationcode_testresult(genocolorectal)
             # @persister.integrate_and_store(genocolorectal)
             res = process_gene(genocolorectal, record)# Added by Francesco
             res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
@@ -83,6 +86,10 @@ module Import
           #   end
           # end
 
+          def add_organisationcode_testresult(genocolorectal)
+            genocolorectal.attribute_map['organisationcode_testresult'] = '696L0'
+          end
+          
           def process_gene(genocolorectal, record)
             genotypes = []
             genes = record.raw_fields['gene']

--- a/lib/import/colorectal/providers/salisbury/salisbury_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/salisbury/salisbury_handler_colorectal.rb
@@ -64,12 +64,17 @@ module Import
             genocolorectal.add_specimen_type(record.mapped_fields['specimentype'])
             genocolorectal.add_received_date(record.raw_fields['date of receipt'])
             extract_teststatus(genocolorectal, record)
+            add_organisationcode_testresult(genocolorectal)
             res = add_colorectal_from_raw_test(genocolorectal, record)
             res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
             status = genocolorectal.attribute_map['teststatus']
             @logger.debug "Extracted Teststatus was #{status}"
           end
 
+          def add_organisationcode_testresult(genocolorectal)
+            genocolorectal.attribute_map['organisationcode_testresult'] = '699H0'
+          end
+          
           def add_colorectal_from_raw_test(genocolorectal, record)
             colo_string = record.raw_fields['test']
             genotypes = []

--- a/lib/import/colorectal/providers/sheffield/sheffield_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/sheffield/sheffield_handler_colorectal.rb
@@ -87,8 +87,13 @@ module Import
                                                   record.raw_fields,
                                                   PASS_THROUGH_FIELDS_COLO)
             add_test_scope_from_karyo(genocolorectal, record)
+            add_organisationcode_testresult(genocolorectal)
             res = add_colorectal_from_raw_test(genocolorectal, record)
             res.map { |cur_genotype| @persister.integrate_and_store(cur_genotype) }
+          end
+
+          def add_organisationcode_testresult(genocolorectal)
+            genocolorectal.attribute_map['organisationcode_testresult'] = '699D0'
           end
 
           def add_test_scope_from_karyo(genocolorectal, record)

--- a/lib/import/colorectal/providers/sheffield/sheffield_handler_colorectal.rb
+++ b/lib/import/colorectal/providers/sheffield/sheffield_handler_colorectal.rb
@@ -165,7 +165,7 @@ module Import
             geno = record.mapped_fields['genetictestscope']
             karyo = record.raw_fields['karyotypingmethod']
             genotypes = []
-            if genocolorectal.attribute_map['genetictestscope'] == 'Targeted Colorectal mutation test'
+            if genocolorectal.attribute_map['genetictestscope'] == 'Targeted Colorectal Lynch or MMR'
               if NULL_TARGETED_TEST_REGEX.match(colo_string)
                 genocolorectal.add_status(1)
                 genocolorectal.add_gene_colorectal(COLORECTAL_GENES_REGEX.match(colo_string)[:colorectal])

--- a/lib/import/helpers/colorectal/providers/r0a/r0a_helper.rb
+++ b/lib/import/helpers/colorectal/providers/r0a/r0a_helper.rb
@@ -131,10 +131,15 @@ module Import
               genocolorectal.add_passthrough_fields(record.mapped_fields,
                                                     record.raw_fields,
                                                     PASS_THROUGH_FIELDS_COLO)
+              add_organisationcode_testresult(genocolorectal)
               add_servicereportidentifier(genocolorectal, record)
               testscope_from_rawfields(genocolorectal, record)
               results = assign_gene_mutation(genocolorectal, record)
               results.each { |genotype| @persister.integrate_and_store(genotype) }
+            end
+
+            def add_organisationcode_testresult(genocolorectal)
+              genocolorectal.attribute_map['organisationcode_testresult'] = '69820'
             end
 
             def assign_gene_mutation(genocolorectal, _record)

--- a/lib/import/helpers/colorectal/providers/rq3/rq3_helper.rb
+++ b/lib/import/helpers/colorectal/providers/rq3/rq3_helper.rb
@@ -15,6 +15,10 @@ module Import
               end
             end
 
+            def add_organisationcode_testresult(genocolorectal)
+              genocolorectal.attribute_map['organisationcode_testresult'] = '699F0'
+            end
+
             def full_screen?(record)
               moleculartestingtype = record.raw_fields['moleculartestingtype'].downcase.strip
               testscope = TEST_SCOPE_MAP_COLO_COLO[moleculartestingtype]

--- a/test/lib/import/colorectal/providers/sheffield/sheffield_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/sheffield/sheffield_handler_colorectal_test.rb
@@ -28,12 +28,21 @@ class SheffieldHandlerColorectalTest < ActiveSupport::TestCase
     Import::Brca::Core::RawRecord.new(default_options.merge!(options))
   end
 
-  test 'add_test_scope_from_karyo' do
+  test 'add_test_scope_from_karyo_fullscreen' do
     @logger.expects(:debug).with('ADDED FULL_SCREEN TEST for: MLH1 MSH2 & MSH6')
     @handler.add_test_scope_from_karyo(@genotype, @record)
   end
 
-  test 'add_colorectal_from_raw_test' do
+  test 'add_test_scope_from_karyo_targeted' do
+    targeted_record = build_raw_record('pseudo_id1' => 'bob')
+    targeted_record.mapped_fields['genetictestscope'] = 'R210 :: Inherited MMR deficiency (Lynch syndrome)'
+    targeted_record.raw_fields['karyotypingmethod'] = 'R242.1 :: Predictive testing'
+    @logger.expects(:debug).with('ADDED TARGETED TEST for: R242.1 :: Predictive testing')
+    @handler.add_test_scope_from_karyo(@genotype, targeted_record)
+  end
+
+
+  test 'add_colorectal_from_raw_test_full_screen' do
     # @logger.expects(:debug).with('ADDED FULL_SCREEN TEST for: MLH1 MSH2 & MSH6')
     # @handler.add_test_scope_from_karyo(@genotype, @record)
     @genotype.attribute_map['genetictestscope'] = 'Full screen Colorectal Lynch or MMR'
@@ -55,6 +64,21 @@ class SheffieldHandlerColorectalTest < ActiveSupport::TestCase
     raw_test = @handler.add_colorectal_from_raw_test(@genotype, @record)
     assert_equal 3, raw_test.size
   end
+
+  test 'add_colorectal_from_raw_test_targeted' do
+    # @logger.expects(:debug).with('ADDED FULL_SCREEN TEST for: MLH1 MSH2 & MSH6')
+    # @handler.add_test_scope_from_karyo(@genotype, @record)
+    @genotype.attribute_map['genetictestscope'] = 'Targeted Colorectal Lynch or MMR'
+    targeted_record = build_raw_record('pseudo_id1' => 'bob')
+    targeted_record.mapped_fields['genetictestscope'] = 'R210 :: Inherited MMR deficiency (Lynch syndrome)'
+    targeted_record.raw_fields['karyotypingmethod'] = 'R242.1 :: Predictive testing'
+    targeted_record.raw_fields['genotype'] = 'c.[2079dup];[2079=]  p.[(Cys694fs)];[(Cys694=)] MSH6 '
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MSH6')
+    @logger.expects(:debug).with('SUCCESSFUL cdna change parse for: 2079dup')
+    @logger.expects(:debug).with('SUCCESSFUL protein change parse for: Cys694fs')
+    @handler.add_colorectal_from_raw_test(@genotype, targeted_record)
+  end
+
 
   test 'process_teststatus' do
     @handler.process_teststatus(@genotype, @record)

--- a/test/lib/import/colorectal/providers/sheffield/sheffield_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/sheffield/sheffield_handler_colorectal_test.rb
@@ -43,8 +43,6 @@ class SheffieldHandlerColorectalTest < ActiveSupport::TestCase
 
 
   test 'add_colorectal_from_raw_test_full_screen' do
-    # @logger.expects(:debug).with('ADDED FULL_SCREEN TEST for: MLH1 MSH2 & MSH6')
-    # @handler.add_test_scope_from_karyo(@genotype, @record)
     @genotype.attribute_map['genetictestscope'] = 'Full screen Colorectal Lynch or MMR'
     @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: MSH2')
     @logger.expects(:debug).with('SUCCESSFUL gene parse for MSH2')
@@ -65,9 +63,92 @@ class SheffieldHandlerColorectalTest < ActiveSupport::TestCase
     assert_equal 3, raw_test.size
   end
 
+  test 'add_colorectal_from_normal_test_full_screen' do
+    @genotype.attribute_map['genetictestscope'] = 'Full screen Colorectal Lynch or MMR'
+    normal_fs_record = build_raw_record('pseudo_id1' => 'bob')
+    normal_fs_record.mapped_fields['genetictestscope'] = 'Colorectal cancer panel'
+    normal_fs_record.raw_fields['karyotypingmethod'] = 'Full panel'
+    normal_fs_record.raw_fields['genotype'] = 'No pathogenic mutation detected'
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MLH1')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MSH2')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MSH6')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for PMS2')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for EPCAM')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for APC')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MUTYH')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for BMPR1A')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for PTEN')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for POLD1')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for POLE')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for SMAD4')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for STK11')
+    @handler.add_colorectal_from_raw_test(@genotype, normal_fs_record)
+  end
+
+
+  test 'add_colorectal_from_incomplete_test_full_screen' do
+    @genotype.attribute_map['genetictestscope'] = 'Full screen Colorectal Lynch or MMR'
+    incomplete_fs_record = build_raw_record('pseudo_id1' => 'bob')
+    incomplete_fs_record.mapped_fields['genetictestscope'] = 'Colorectal cancer panel'
+    incomplete_fs_record.raw_fields['karyotypingmethod'] = 'MLH1 MSH2 & MSH6'
+    incomplete_fs_record.raw_fields['genotype'] = 'Incomplete analysis - see below'
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: MLH1')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MLH1')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: MSH2')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MSH2')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: MSH6')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MSH6')
+    @handler.add_colorectal_from_raw_test(@genotype, incomplete_fs_record)
+  end
+
+  test 'add_colorectal_from_multiple_genes_full_screen' do
+    @genotype.attribute_map['genetictestscope'] = 'Full screen Colorectal Lynch or MMR'
+    multiplegenes_fs_record = build_raw_record('pseudo_id1' => 'bob')
+    multiplegenes_fs_record.mapped_fields['genetictestscope'] = 'Colorectal cancer panel'
+    multiplegenes_fs_record.raw_fields['karyotypingmethod'] = 'Full panel'
+    multiplegenes_fs_record.raw_fields['genotype'] = '"SMAD4:c.[1573A>G];[=]  p.[(Ile525Val)];[(=)] MUTYH: c.[1014G>C ];[=]  p.[(Glu338His)];[(=)] -See below'
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: MLH1')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MLH1')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: MSH2')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MSH2')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: MSH6')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MSH6')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: PMS2')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for PMS2')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: EPCAM')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for EPCAM')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: APC')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for APC')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: BMPR1A')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for BMPR1A')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: PTEN')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for PTEN')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: POLD1')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for POLD1')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: POLE')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for POLE')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: STK11')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for STK11')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for SMAD4')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MUTYH')
+    @handler.add_colorectal_from_raw_test(@genotype, multiplegenes_fs_record)
+  end
+
+  test 'add_colorectal_from_multiple_genes_karyofield_full_screen' do
+
+    @genotype.attribute_map['genetictestscope'] = 'Full screen Colorectal Lynch or MMR'
+    normalmultiplekaryo_fs_record = build_raw_record('pseudo_id1' => 'bob')
+    normalmultiplekaryo_fs_record.mapped_fields['genetictestscope'] = 'R209 :: Inherited colorectal cancer (with or without polyposis)'
+    normalmultiplekaryo_fs_record.raw_fields['karyotypingmethod'] = 'R209.1 :: NGS - APC and MUTYH only'
+    normalmultiplekaryo_fs_record.raw_fields['genotype'] = 'No pathogenic mutation detected'
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for APC')
+    @logger.expects(:debug).with('SUCCESSFUL gene parse for MUTYH')
+    @handler.add_colorectal_from_raw_test(@genotype, normalmultiplekaryo_fs_record)
+  end
+  
+  
   test 'add_colorectal_from_raw_test_targeted' do
-    # @logger.expects(:debug).with('ADDED FULL_SCREEN TEST for: MLH1 MSH2 & MSH6')
-    # @handler.add_test_scope_from_karyo(@genotype, @record)
+
     @genotype.attribute_map['genetictestscope'] = 'Targeted Colorectal Lynch or MMR'
     targeted_record = build_raw_record('pseudo_id1' => 'bob')
     targeted_record.mapped_fields['genetictestscope'] = 'R210 :: Inherited MMR deficiency (Lynch syndrome)'
@@ -79,6 +160,17 @@ class SheffieldHandlerColorectalTest < ActiveSupport::TestCase
     @handler.add_colorectal_from_raw_test(@genotype, targeted_record)
   end
 
+  test 'add_colorectal_from_null_test_targeted' do
+    @genotype.attribute_map['genetictestscope'] = 'Targeted Colorectal Lynch or MMR'
+    targeted_record = build_raw_record('pseudo_id1' => 'bob')
+    targeted_record.mapped_fields['genetictestscope'] = 'R210 :: Inherited MMR deficiency (Lynch syndrome)'
+    targeted_record.raw_fields['karyotypingmethod'] = 'R242.1 :: Predictive testing'
+    targeted_record.raw_fields['genotype'] = 'Familial likely pathogenic mutation NOT detected'
+    @logger.expects(:error).with('Bad input type given for colorectal extraction: ')
+    @handler.add_colorectal_from_raw_test(@genotype, targeted_record)
+    @logger.expects(:error).with('Bad input type given for colorectal extraction: ')
+    assert_equal 1, @handler.add_colorectal_from_raw_test(@genotype, targeted_record)[0].attribute_map['teststatus']
+  end
 
   test 'process_teststatus' do
     @handler.process_teststatus(@genotype, @record)


### PR DESCRIPTION
-Tweaked RCU, RPY and RR8 colorectal providers after Q&A with molecular analysts
-Added methods in BRCA and Colorectal providers to populate `organisationcode_testresult` column in `molecular_data` table
