### PR TITLE
Adjust some capybara waits and selectors

### DIFF
--- a/test/integration/cas_application_form_test.rb
+++ b/test/integration/cas_application_form_test.rb
@@ -94,12 +94,12 @@ class CasApplicationFormTest < ActionDispatch::IntegrationTest
 
     visit project_path(application)
 
-    assert_not has_content?('Contract start date')
-    assert_not has_content?('Contract end date')
-    assert_not has_content?('Preferred username')
-    assert_not has_content?('Full physical addresses & postcodes CAS will be accessed from')
-    assert_not has_content?('N3 IP address CAS will be accessed from')
-    assert_not has_content?('I have completed the relevant data access forms for the ONS ' \
+    assert has_no_content?('Contract start date')
+    assert has_no_content?('Contract end date')
+    assert has_no_content?('Preferred username')
+    assert has_no_content?('Full physical addresses & postcodes CAS will be accessed from')
+    assert has_no_content?('N3 IP address CAS will be accessed from')
+    assert has_no_content?('I have completed the relevant data access forms for the ONS ' \
                             'incidence dataset')
   end
 

--- a/test/integration/cas_dataset_approval_test.rb
+++ b/test/integration/cas_dataset_approval_test.rb
@@ -70,7 +70,7 @@ class CasDatasetApprovalTest < ActionDispatch::IntegrationTest
     click_link(href: '#datasets')
     assert has_content?('Extra CAS Dataset One')
     assert_equal find('#dataset_status').text, 'APPROVED'
-    assert_not has_content?('Reapply')
+    assert has_no_content?('Reapply')
 
     project_dataset.approved = false
     project_dataset.save!(validate: false)
@@ -83,8 +83,8 @@ class CasDatasetApprovalTest < ActionDispatch::IntegrationTest
     click_link('Reapply')
 
     assert has_content?('PENDING')
-    assert_not page.has_css?('.btn-danger')
-    assert_not page.has_css?('.btn-success')
+    assert has_no_css?('.btn-danger')
+    assert has_no_css?('.btn-success')
     assert_nil project_dataset.reload.approved
   end
 
@@ -130,12 +130,12 @@ class CasDatasetApprovalTest < ActionDispatch::IntegrationTest
     within("#project_dataset_#{grant_dataset.id}") do
       assert has_css?('.btn-danger')
       assert has_css?('.btn-success')
-      assert_not has_content?('PENDING')
+      assert has_no_content?('PENDING')
     end
 
     within("#project_dataset_#{non_grant_dataset.id}") do
-      assert_not has_css?('.btn-danger')
-      assert_not has_css?('.btn-success')
+      assert has_no_css?('.btn-danger')
+      assert has_no_css?('.btn-success')
       assert_equal find('#dataset_status').text, 'PENDING'
     end
 
@@ -147,8 +147,8 @@ class CasDatasetApprovalTest < ActionDispatch::IntegrationTest
     click_link(href: '#datasets')
 
     within("#project_dataset_#{non_grant_dataset.id}") do
-      assert_not has_css?('.btn-danger')
-      assert_not has_css?('.btn-success')
+      assert has_no_css?('.btn-danger')
+      assert has_no_css?('.btn-success')
       assert_equal find('#dataset_status').text, 'APPROVED'
     end
 
@@ -160,8 +160,8 @@ class CasDatasetApprovalTest < ActionDispatch::IntegrationTest
     click_link(href: '#datasets')
 
     within("#project_dataset_#{non_grant_dataset.id}") do
-      assert_not has_css?('.btn-danger')
-      assert_not has_css?('.btn-success')
+      assert has_no_css?('.btn-danger')
+      assert has_no_css?('.btn-success')
       assert_equal find('#dataset_status').text, 'DECLINED'
     end
   end

--- a/test/integration/create_and_edit_user_test.rb
+++ b/test/integration/create_and_edit_user_test.rb
@@ -105,11 +105,11 @@ class CreateAndEditUserTest < ActionDispatch::IntegrationTest
 
     assert has_content?('no_roles@phe.gov.uk')
 
-    assert find('#user_first_name').readonly?
-    assert find('#user_last_name').readonly?
-    assert find('#user_username').readonly?
-    assert find('#user_email').readonly?
-    assert_not find('#user_job_title').readonly?
+    assert has_field?('user[first_name]', readonly: true)
+    assert has_field?('user[last_name]', readonly: true)
+    assert has_field?('user[username]', readonly: true)
+    assert has_field?('user[email]', readonly: true)
+    assert has_field?('user[job_title]', readonly: false)
 
     # User shouldn't be able to set these for themselves
     assert has_no_content?('Status')
@@ -126,11 +126,11 @@ class CreateAndEditUserTest < ActionDispatch::IntegrationTest
 
     assert has_content?('no_roles@phe.gov.uk')
 
-    assert_not find('#user_first_name').readonly?
-    assert_not find('#user_last_name').readonly?
-    assert_not find('#user_username').readonly?
-    assert_not find('#user_email').readonly?
-    assert_not find('#user_job_title').readonly?
+    assert has_field?('user[first_name]', readonly: false)
+    assert has_field?('user[last_name]', readonly: false)
+    assert has_field?('user[username]', readonly: false)
+    assert has_field?('user[email]', readonly: false)
+    assert has_field?('user[job_title]', readonly: false)
 
     # User shouldn't be able to set these for themselves
     assert has_content?('Status')
@@ -147,11 +147,11 @@ class CreateAndEditUserTest < ActionDispatch::IntegrationTest
 
     assert has_content?('no_roles@phe.gov.uk')
 
-    assert_not find('#user_first_name').readonly?
-    assert_not find('#user_last_name').readonly?
-    assert_not find('#user_username').readonly?
-    assert_not find('#user_email').readonly?
-    assert_not find('#user_job_title').readonly?
+    assert has_field?('user[first_name]', readonly: false)
+    assert has_field?('user[last_name]', readonly: false)
+    assert has_field?('user[username]', readonly: false)
+    assert has_field?('user[email]', readonly: false)
+    assert has_field?('user[job_title]', readonly: false)
 
     # User shouldn't be able to set these for themselves
     assert has_content?('Status')


### PR DESCRIPTION
This PR ensures there's no unnecessary waiting done by Capybara, slowing the test suite down. Also, flips some uses of `find` to include the `readonly` selector in what Capybara is waiting for - this should avoid spurious failures if the field is not yet been made readonly (e.g. by JavaScript).