### PR TITLE
Enable parallel testing

### DIFF
--- a/lib/nodes/utility.rb
+++ b/lib/nodes/utility.rb
@@ -1,6 +1,10 @@
 module Nodes
   # Shared methods for buliding schema browser and change log
   module Utility
+    def self.schema_pack_location
+      @schema_pack_location ||= Rails.root.join('tmp')
+    end
+
     def indent
       ' ' * (@depth * 2)
     end
@@ -11,7 +15,7 @@ module Nodes
 
     def save_schema_pack_file(output, filename, zipfile = nil)
       if zipfile.nil?
-        File.open(Rails.root.join('tmp', filename), 'w') do |f|
+        File.open(Utility.schema_pack_location.join(filename), 'w') do |f|
           f.write output
         end
       else

--- a/test/integration/admin/can_manage_data_items_test.rb
+++ b/test/integration/admin/can_manage_data_items_test.rb
@@ -78,7 +78,7 @@ class CanManageDataItemsTest < ActionDispatch::IntegrationTest
     find_button('New Node').click
     find_link('Entity').click
 
-    within_modal(remain: true) do
+    within_modal do
       fill_in 'Name',        with: 'New Entity'
       fill_in 'Min Occurs',  with: 1
       fill_in 'Max Occurs',  with: 2
@@ -122,7 +122,7 @@ class CanManageDataItemsTest < ActionDispatch::IntegrationTest
     find_button('New Node').click
     find_link('Data Item').click
 
-    within_modal(remain: true) do
+    within_modal do
       fill_in 'Name',        with: 'New Data Item With Data Dictionary Element'
       fill_in 'Min Occurs',  with: 1
       fill_in 'Max Occurs',  with: 2

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -458,7 +458,7 @@ class ProjectTest < ActiveSupport::TestCase
     projects = Project.where(id: projects.pluck(:id))
 
     assert_equal 4, projects.by_project_type(:all).count
-    assert_equal %w[EOI Application], projects.by_project_type(:odr).map(&:project_type_name)
+    assert_equal %w[Application EOI], projects.by_project_type(:odr).map(&:project_type_name).sort
     assert_equal %w[Project], projects.by_project_type(:project).map(&:project_type_name)
     assert_equal %w[CAS], projects.by_project_type(:cas).map(&:project_type_name)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,10 +25,9 @@ require_relative 'download_helpers'
 
 Capybara.server = :puma, { Silent: true }
 
-# Test switch is flakey on CI; looking at logs, many requests there taking
-# longer than the default 2 second wait, meaning a good chance (some of)
-# the flakiness might be being caused by that...
-Capybara.default_max_wait_time = 5.seconds
+# When running in parallel, there can be occassional chokes, so this accounts for that.
+# This shouldn't slow down tests that are well-written.
+Capybara.default_max_wait_time = 10.seconds
 
 # Devise support for functional / integration test
 module ActionDispatch

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -131,7 +131,7 @@ module ActiveSupport
     # Something about MBIS doesn't like parallel testing. Very noticeable on the CI
     # platform, occassionally also developing locally. For now, will disable parallel
     # testing unless the `PARALLEL_WORKERS` variable is explicitly set.
-    parallelize(workers: ENV.fetch('PARALLEL_WORKERS', 1).to_i)
+    parallelize(workers: :number_of_processors)
 
     # Re-bootstrap for the multi process case:
     parallelize_setup do
@@ -162,11 +162,6 @@ module ActiveSupport
       within :xpath, "//table//tr[td[contains(.,\"#{text}\")]]" do
         yield
       end
-    end
-
-    # You shouldn't need this...
-    def snooze(seconds)
-      sleep(seconds) unless ENV.key?('WAKEY_WAKEY')
     end
 
     require 'mocha/mini_test'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -126,6 +126,9 @@ end
 # Bootstrap for the single process case:
 bootstrap_download_helper
 
+# Ensure the driver is installed in advance of any parallel testing.
+Webdrivers::Chromedriver.update
+
 module ActiveSupport
   class TestCase
     # Something about MBIS doesn't like parallel testing. Very noticeable on the CI


### PR DESCRIPTION
This PR makes a number of changes to the test suite in order to allow it to run in parallel using the Rails 6 parallelism mechanism (multiprocess, fork-based).

- [x] target flakey test
- [x] refactor schema tests to use ephemeral location + cleanup
- [x] address chrome driver modal issues
- [x] enable parallel testing by default