### PR TITLE
Improve schema generation performance

### DIFF
--- a/app/models/nodes/category_choice.rb
+++ b/app/models/nodes/category_choice.rb
@@ -7,6 +7,7 @@ module Nodes
                       optional: true, inverse_of: :data_items
     belongs_to :entity, class_name: 'Nodes::Entity', foreign_key: 'parent_id',
                         optional: true, inverse_of: :category_choices
+    # TODO: keep normal inverse here
     has_many :child_nodes, class_name: 'Node', foreign_key: 'parent_id',
                            dependent: :destroy, inverse_of: :category_choice
 
@@ -60,12 +61,12 @@ module Nodes
 
     def samples_for(choices, options)
       choices.each do |choice|
-        parent_choice_ids = choice.parent_choices_to_get_to_this_choice
+        parent_choices = choice.parent_choices_to_get_to_this_choice
         choice.valid_choice_combinations.each.with_index(1) do |combination, i|
           # For each choice make the simplest valid sample xml record possible
           choice.categories_for_sample_choice.each do |category|
             node_options = { xml: options[:xml], category: category, choice: combination,
-                             parent_choices: parent_choice_ids, choice_no: i }
+                             parent_choices: parent_choices, choice_no: i }
             build_child_node_samples(options, node_options)
           end
         end

--- a/app/models/nodes/data_item.rb
+++ b/app/models/nodes/data_item.rb
@@ -16,12 +16,21 @@ module Nodes
                        optional: true, inverse_of: :data_items
     belongs_to :data_item_group, class_name: 'Nodes::DataItemGroup', foreign_key: 'parent_id',
                                  optional: true, inverse_of: :data_items
-                        
+
     belongs_to :xml_type, optional: true
     belongs_to :data_dictionary_element, optional: true
 
     delegate :name, :link, :format_length, :national_codes,
              to: :data_dictionary_element, prefix: true, allow_nil: true
+
+    def self.preload_strategy
+      superclass.preload_strategy + [
+        xml_type: { enumeration_values: :dataset_versions },
+        data_dictionary_element: {
+          xml_type: { enumeration_values: :dataset_versions }
+        }
+      ]
+    end
 
     # If we have no data dictionary element yet, use direct association to xml_type
     def xmltype

--- a/app/models/nodes/dataset_version_lookup.rb
+++ b/app/models/nodes/dataset_version_lookup.rb
@@ -32,7 +32,7 @@ module Nodes
                                                                            entity_items: {} } }
       all_categories(dataset_version).each do |category|
         lookup[dataset_version.name][dataset_version.semver_version][:xsd_names][category] = {}
-        dataset_version.entities.each_with_object({}) do |entity, entity_lookup|
+        dataset_version.preloaded_entities.each_with_object({}) do |entity, entity_lookup|
           next unless entity.node_for_category?(category)
           entity_lookup[entity.name] = { element_name: entity.xsd_element_name,
                                          type_name: entity.xsd_type_name(category) }

--- a/app/models/nodes/entity.rb
+++ b/app/models/nodes/entity.rb
@@ -83,7 +83,7 @@ module Nodes
     end
   
     def choice_in_children?(options)
-      Node.where(id: options[:choice]).any? { |n| n.in_child_path_for?(self) }
+      Array.wrap(options[:choice]).any? { |n| n.in_child_path_for?(self) }
     end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.active_record.verbose_query_logs = true
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that

--- a/lib/xsd/constituent_parts/category.rb
+++ b/lib/xsd/constituent_parts/category.rb
@@ -29,7 +29,7 @@ module Xsd
 
       def xsd_category(category)
         # Assuming only one Nodes::Category per version
-        category_choice_node = dataset_version.nodes.find_by(type: 'Nodes::CategoryChoice')
+        category_choice_node = dataset_version.preloaded_descendants.find(&:category_choice?)
         schema.xs :schema, ns('xs', :w3, :schema, true) do |schema_|
           category_choice_node.build_category(schema_, category)
         end

--- a/lib/xsd/constituent_parts/master.rb
+++ b/lib/xsd/constituent_parts/master.rb
@@ -58,7 +58,7 @@ module Xsd
 
       def build_record_parents(schema)
         entity_file_list = dataset_version.first_level_of_version_child_entities +
-                             dataset_version.entities.where(name: dataset_name)
+                             [dataset_version.version_entity]
         entity_file_list.each do |entity|
           entity.complex_entity(schema, true)
           entity.child_nodes.groups.each do |group|

--- a/lib/xsd/schema_files.rb
+++ b/lib/xsd/schema_files.rb
@@ -18,6 +18,8 @@ module Xsd
     end
 
     def build
+      @dataset_version.preloaded_descendants
+
       master_file
       xml_types_file
       record_entities_file

--- a/test/models/nodes/choice_test.rb
+++ b/test/models/nodes/choice_test.rb
@@ -133,7 +133,7 @@ module Nodes
       choice_node.save!
       choice_node.reload
       actual = choice_node.mandatory_choice_combinations.sort
-      expected = choice_node.child_nodes.pluck(:id).map { |i| [i] }.sort
+      expected = choice_node.child_nodes.map { |i| [i] }.sort
       assert_equal  expected, actual, 'choice combinations not expected'
     end
 
@@ -144,7 +144,7 @@ module Nodes
       choice_node.save!
       choice_node.reload
       actual = choice_node.valid_choice_combinations.sort
-      expected = choice_node.child_nodes.pluck(:id).map { |i| [i] }
+      expected = choice_node.child_nodes.map { |i| [i] }
       expected << []
       assert_equal expected.sort, actual, 'choice combinations not expected'
     end
@@ -156,7 +156,7 @@ module Nodes
       choice_node.save!
       choice_node.reload
       actual = choice_node.valid_choice_combinations.sort
-      expected = choice_node.child_nodes.pluck(:id).sort
+      expected = choice_node.child_nodes.sort
       assert_equal expected.sort, actual, 'choice combinations not expected'
     end
 


### PR DESCRIPTION
This PR makes a start on trying to improve the performance of schema generation, by trying to cache as much of the node structure as possible within the Rails associations.

This is complicated by:
* the fact that the `DatasetVersion` is often used as the "root object", whereas in actual fact it the `version_entity` might be more straightforward from a performance point-of-view
* that the `:child_nodes` association used to recursively load the node hierarchy is sometimes redefined with a `:inverse_of` that's not equal to the default `:parent_node`. This causes some down-then-up-the-tree traversals to arrive at nodes that have not been optimally cached.

However, these two points aside, this does radically improve the performance of the schema tests:

```diff
$ PARALLEL_WORKERS=1 bin/rails test test/models/schema_test.rb

- Finished in 131.115022s, 0.0686 runs/s, 0.0000 assertions/s.
+ Finished in 17.121049s, 0.5257 runs/s, 0.0000 assertions/s.
9 runs, 0 assertions, 0 failures, 0 errors, 0 skips
```

Given that this timing includes inserting fixtures and running the tests, timing more precisely:

```diff
- built in 122.391881627
+ built in 9.185320702 
```

...so a 13.5x speedup.

Hopefully this should help a little with CI build times, too. I had been looking into trying to pin the schema tests to a single test worker, but I think the setup overhead is not sufficiently lower that it's probably not worth it.