### PR TITLE
# Remove comment deletion ability [#22700]

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,7 +10,7 @@ class Ability
 
     # NOTE: If `user` can :read the parent resource then it is assumed that they should be able to
     # :read any/all `comment`s on that resource (hence no :read permission defined for `Comment`).
-    can %i[create destroy], Comment, user_id: user.id
+    can %i[create], Comment, user_id: user.id
 
     can %i[terms_and_conditions read destroy], Notification
     can :destroy, UserNotification, user_id: user.id

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -898,7 +898,7 @@ class AbilityTest < ActiveSupport::TestCase
     )
 
     assert user.can? :create, comment_one
-    assert user.can? :delete, comment_one
+    refute user.can? :delete, comment_one
     refute user.can? :create, comment_two
     refute user.can? :delete, comment_two
   end


### PR DESCRIPTION
It's been decided that comment deletion is an unwanted feature, so this is a quick PR to close off that functionality. 