### PR TITLE
# Clone parent project details on create

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -118,7 +118,6 @@ class ProjectsController < ApplicationController
         format.html { redirect_to @project, notice: "#{@project.project_type_name} was successfully created." }
         format.js { render action: 'show', id: @project.id }
       end
-      @project.send(:clone_project_sub_details)
       # send mail
     else
       form_type = project_params['clone_of'].presence ? :duplicate : :new

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -72,6 +72,7 @@ class Project < ApplicationRecord
 
   after_save :reset_project_data_items
   after_create :notify_cas_manager_new_cas_project_saved
+  after_create :clone_project_sub_details
 
   # effectively belongs_to .. through: .. association
   # delegate :dataset,      to: :team_dataset, allow_nil: true

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -211,18 +211,14 @@ class ProjectTest < ActiveSupport::TestCase
     cloned_project.owner = original_project.owner
     cloned_project.save!
 
-    refute cloned_project.end_uses == original_project.end_uses
-    refute cloned_project.classifications == original_project.classifications
-    refute cloned_project.outputs == original_project.outputs
-
-    cloned_project.send(:clone_project_sub_details)
     # original items remain
     assert original_project.end_uses.count.positive?
     assert original_project.classifications.count.positive?
     assert original_project.outputs.count.positive?
-    assert cloned_project.end_uses, original_project.end_uses
-    assert cloned_project.classifications, original_project.classifications
-    assert cloned_project.outputs, original_project.outputs
+
+    assert_equal original_project.end_uses, cloned_project.end_uses
+    assert_equal original_project.classifications, cloned_project.classifications
+    assert_equal original_project.outputs, cloned_project.outputs
   end
 
   test 'should only be assignable to application managers' do


### PR DESCRIPTION
This PR switches to using an `after_create` callback. This avoids the need to separately call private methods in order to make this cloning happen.

It might be possible to use a `before_create` callback, and be a bit more efficient with DB updates, but I think there is also an issue around parent project details actually overwriting users' choices with things like `end_uses` – so it would be good to bottom that out first with someone who is familiar.