### PR TITLE
Add resource for recording dialogue between applicant and ODR [#26533]

### DIFF
--- a/app/controllers/communications_controller.rb
+++ b/app/controllers/communications_controller.rb
@@ -1,0 +1,75 @@
+# RESTfully manages `Communication` resources
+class CommunicationsController < ApplicationController
+  load_and_authorize_resource :project
+  load_and_authorize_resource through: :project, shallow: true
+
+  # Ensure that any associations are correctly scoped to the project.
+  with_options only: %i[create] do
+    before_action :set_parent
+    before_action :set_sender
+    before_action :set_recipient
+  end
+
+  def index
+    @communications = @communications.
+                      includes(:parent, :sender, :recipient).
+                      order(contacted_at: :desc, id: :desc)
+
+    locals = {
+      project: @project,
+      communications: @communications,
+      comments_count: @communications.joins(:comments).group(:id).count
+    }
+
+    respond_to do |format|
+      format.html { render partial: 'communications', locals: locals, content_type: :html }
+    end
+  end
+
+  def new
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  def create
+    @communication.save
+
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  def destroy
+    @communication.destroy
+
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  private
+
+  def resource_params
+    params.require(:communication).
+      permit(:parent_id, :sender_id, :recipient_id, :contacted_at, :medium)
+  end
+
+  def set_parent
+    return unless id ||= params.dig(:communication, :parent_id)
+
+    @communication.parent = @project.communications.find_by(id: id)
+  end
+
+  def set_sender
+    return unless id ||= params.dig(:communication, :sender_id)
+
+    @communication.sender = @project.users.find_by(id: id)
+  end
+
+  def set_recipient
+    return unless id ||= params.dig(:communication, :recipient_id)
+
+    @communication.recipient = @project.users.find_by(id: id)
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -63,6 +63,7 @@ class ProjectsController < ApplicationController
     @readonly = true
     @team = @project.team
     @sub_resource_counts = {
+      'communications': @project.communications.count,
       'comments': @project.comments.count,
       'project_nodes.comments': @project.project_nodes.joins(:comments).group(:id).count,
       'workflow/project_states.comments': @project.project_states.joins(:comments).group(:id).count

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -278,6 +278,8 @@ class Ability
 
     can %i[create read update destroy], Release
 
+    can %i[create read destroy], Communication
+
     can :read, [ProjectEndUse, ProjectClassification, ProjectLawfulBasis]
   end
 

--- a/app/models/communication.rb
+++ b/app/models/communication.rb
@@ -1,0 +1,30 @@
+# Records when dialogue between applicants and application management took place.
+class Communication < ApplicationRecord
+  include Commentable
+
+  belongs_to :project
+
+  belongs_to :sender,    class_name: 'User'
+  belongs_to :recipient, class_name: 'User'
+
+  belongs_to :parent, class_name:  'Communication', optional: true
+  has_many :children, class_name:  'Communication',
+                      foreign_key: :parent_id,
+                      inverse_of:  :parent,
+                      dependent:   :destroy
+
+  has_paper_trail
+
+  enum medium: { email: 1, phone: 2, letter: 3, in_person: 4 }
+
+  validates :medium,       presence: true
+  validates :contacted_at, presence: true
+  validates :contacted_at, date: { no_future: true }
+  validates :contacted_at, date: { not_before: :parent_contacted_at }, if: -> { parent_id.present? }
+
+  with_options prefix: true do
+    delegate :full_name,    to: :sender
+    delegate :full_name,    to: :recipient
+    delegate :contacted_at, to: :parent
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -23,6 +23,7 @@ class Project < ApplicationRecord
   has_many :dpias, class_name: 'DataPrivacyImpactAssessment', dependent: :destroy
   has_many :contracts, dependent: :destroy
   has_many :releases,  dependent: :destroy
+  has_many :communications, dependent: :destroy
 
   has_many :project_lawful_bases, dependent: :destroy
   has_many :lawful_bases, through: :project_lawful_bases

--- a/app/views/communications/_communication.html.erb
+++ b/app/views/communications/_communication.html.erb
@@ -1,0 +1,27 @@
+<%
+  comments_count ||= 0
+%>
+
+<%= content_tag(:tr, class: dom_class(communication), id: dom_id(communication)) do %>
+  <td><%= communication.id %></td>
+  <td><%= communication.sender_full_name %></td>
+  <td><%= communication.recipient_full_name %></td>
+  <td><%= communication.contacted_at.to_s(:ui) %></td>
+  <td><%= communication.medium.titleize %></td>
+  <td><%= "re: #{communication.parent_id}" if communication.parent_id %></td>
+  <td class="text-right">
+    <%= link_to(polymorphic_path([communication, :comments]), remote: true) do %>
+      <%= Comment.model_name.human.pluralize %>
+      <%= comments_count_badge_for(communication, comments_count) %>
+    <% end %>
+  </td>
+  <td>
+    <div class="pull-right">
+      <% new_response_params = { communication: { parent_id: communication.id, sender_id: communication.recipient_id, recipient_id: communication.sender_id } } %>
+      <%= link_to new_project_communication_path(communication.project, new_response_params), class: 'btn btn-default btn-xs', title: 'Log Response', remote: true do %>
+        <span class="glyphicon glyphicon-share" style="transform: scaleX(-1);"></span>
+      <% end %>
+      <%= delete_link(communication, remote: true) %>
+    </div>
+  </td>
+<% end %>

--- a/app/views/communications/_communications.html.erb
+++ b/app/views/communications/_communications.html.erb
@@ -1,0 +1,29 @@
+<%
+  comments_count ||= {}
+%>
+
+<div class="table-responsive">
+  <table class="table" id="communications_table">
+    <thead>
+      <tr>
+        <th><%= Communication.human_attribute_name(:id) %></th>
+        <th><%= Communication.human_attribute_name(:sender) %></th>
+        <th><%= Communication.human_attribute_name(:recipient) %></th>
+        <th><%= Communication.human_attribute_name(:contacted_at) %></th>
+        <th><%= Communication.human_attribute_name(:medium) %></th>
+        <th><%= Communication.human_attribute_name(:parent) %></th>
+        <th></th>
+        <th>
+          <div class="pull-right">
+            <%= link_to bootstrap_icon_tag('plus-sign') + ' New', new_project_communication_path(project), class: 'btn btn-primary btn-xs', remote: true %>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <% communications.each do |communication| %>
+        <%= render communication, comments_count: comments_count.fetch(communication.id, 0) %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/communications/_form.html.erb
+++ b/app/views/communications/_form.html.erb
@@ -1,0 +1,39 @@
+<%
+  readonly ||= false
+  project  ||= communication.project
+
+  url = url_for(communication) if communication.persisted?
+  url ||= polymorphic_url([project, :communications])
+
+  form_html_options = {
+    class: dom_class(communication),
+    id: dom_id(communication)
+  }
+%>
+
+<%= bootstrap_form_with(model: communication, url: url, readonly: readonly, horizontal: true, local: false, html: form_html_options) do |form| %>
+  <%= form.hidden_field :parent_id, value: params.dig(:communication, :parent_id) %>
+
+  <%= form.error_and_warning_alert_boxes %>
+
+  <%= form.control_group(:sender) do %>
+    <%= form.collection_select(:sender_id, project.users, :id, :full_name, { include_blank: true }, class: 'form-control') %>
+  <% end %>
+
+  <%= form.control_group(:recipient) do %>
+    <%= form.collection_select(:recipient_id, project.users, :id, :full_name, { include_blank: true }, class: 'form-control') %>
+  <% end %>
+
+  <%= form.control_group(:contacted_at) do %>
+    <%= form.datepicker_field(:contacted_at) %>
+  <% end %>
+
+  <%= form.control_group(:medium) do %>
+    <%= form.select :medium, Communication.media.keys.map { |key| [key.titleize, key] }, include_blank: true %>
+  <% end %>
+
+  <hr />
+  <div class="text-right">
+    <%= form.submit 'Save', class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/communications/create.js.erb
+++ b/app/views/communications/create.js.erb
@@ -1,0 +1,21 @@
+<% if @communication.errors.any? %>
+  <% html = render 'form', communication: @communication %>
+
+  $('#new_communication').html('<%= j(html) %>');
+<% else %>
+  <% html = render 'communication', communication: @communication %>
+
+  var $table = $('#communications_table');
+  var $row = $('<%= j(html) %>');
+  var $badge = $('a[href="#communications"] .badge');
+  var count = +$badge.text();
+
+  $badge.text(count + 1);
+
+  $row.hide().
+    prependTo($table).
+    fadeIn();
+
+  $('#modal').modal('hide');
+  $('#new_communication').remove();
+<% end %>

--- a/app/views/communications/destroy.js.erb
+++ b/app/views/communications/destroy.js.erb
@@ -1,0 +1,10 @@
+<% if @communication.destroyed? %>
+  var $badge = $('a[href="#communications"] .badge');
+  var count = +$badge.text();
+
+  $badge.text(count - 1);
+
+  $('#<%= j(dom_id(@communication)) %>').fadeOut(function() {
+    $(this).remove();
+  });
+<% end %>

--- a/app/views/communications/new.js.erb
+++ b/app/views/communications/new.js.erb
@@ -1,0 +1,6 @@
+<% title = "New #{Communication.model_name.human}" %>
+<% html  = render 'form', communication: @communication %>
+
+$('#modal_title').text('<%= j(title) %>');
+$('#modal_body').html('<%= j(html) %>');
+$('#modal').modal('show');

--- a/app/views/projects/_communications.html.erb
+++ b/app/views/projects/_communications.html.erb
@@ -1,0 +1,9 @@
+<div class="panel panel-default" style="border-top: 0px;">
+  <div class="panel-heading" style="font-size: 1.5em;">
+    <%= Communication.model_name.human.pluralize %>
+  </div>
+</div>
+
+<%= async_content_tag(:div, project_communications_path(project)) do %>
+  <strong>Loading...</strong>
+<% end %>

--- a/app/views/projects/application/_show_project_tab_panels.html.erb
+++ b/app/views/projects/application/_show_project_tab_panels.html.erb
@@ -48,6 +48,12 @@
     <%= render 'project_comments', project: project, comments_count: sub_resource_counts.fetch(:comments, 0) %>
   </div>
 
+  <% if can?(:read, Communication) %>
+    <div class="tab-pane" id="communications">
+      <%= render 'communications', project: project, comments_count: 0 %>
+    </div>
+  <% end %>
+
   <%= render 'project_timeline',  project: @project, comments_count: sub_resource_counts.fetch(:'workflow/project_states.comments', {}) %>
   <%= render 'project_heirarchy', project: @project %>
 </div>

--- a/app/views/projects/application/_show_project_tabs.html.erb
+++ b/app/views/projects/application/_show_project_tabs.html.erb
@@ -33,6 +33,9 @@
       <%= comments_count_badge_for(project, sub_resource_counts.fetch(:comments, 0)) %>
     </a>
   </li>
+  <% if can?(:read, Communication) %>
+    <%= tab_to Communication.model_name.human.pluralize, '#communications', count: sub_resource_counts.fetch(:communications, 0), data: { toggle: :tab } %>
+  <% end %>
   <li>
     <a href="#timeline" data-toggle="tab">Timeline</a>
   </li>

--- a/app/views/projects/eoi/_show_project_tab_panels.html.erb
+++ b/app/views/projects/eoi/_show_project_tab_panels.html.erb
@@ -23,6 +23,12 @@
     <%= render 'project_comments', project: project, comments_count: sub_resource_counts.fetch(:comments, 0) %>
   </div>
 
+  <% if can?(:read, Communication) %>
+    <div class="tab-pane" id="communications">
+      <%= render 'communications', project: project, comments_count: 0 %>
+    </div>
+  <% end %>
+
   <%= render 'project_datasets',  project: @project %>
   <%= render 'project_timeline',  project: @project, comments_count: sub_resource_counts.fetch('workflow/project_states.comments', {}) %>
   <%= render 'project_heirarchy', project: @project %>

--- a/app/views/projects/eoi/_show_project_tabs.html.erb
+++ b/app/views/projects/eoi/_show_project_tabs.html.erb
@@ -11,6 +11,11 @@
       <%= comments_count_badge_for(project, sub_resource_counts.fetch(:comments, 0)) %>
     </a>
   </li>
+
+  <% if can?(:read, Communication) %>
+    <%= tab_to Communication.model_name.human.pluralize, '#communications', count: sub_resource_counts.fetch(:communications, 0), data: { toggle: :tab } %>
+  <% end %>
+
   <li>
     <a href="#datasets" data-toggle="tab">Datasets</a>
   </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -354,3 +354,8 @@ en:
         drr_no: DRR No
         individual_to_release: Name(s) of individuals releasing data
         release_date: Data Release date
+      communication:
+        id: ID
+        contacted_at: Contact Date
+        medium: Method
+        parent: Responding To

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,6 +206,7 @@ Rails.application.routes.draw do
       resources :data_privacy_impact_assessments, concerns: %i[downloadable]
       resources :contracts, concerns: %i[downloadable]
       resources :releases
+      resources :communications, except: %i[show edit update], concerns: %i[commentable]
 
       namespace :workflow do
         resources :project_states, only: [] do

--- a/db/migrate/20210506093309_create_communications.rb
+++ b/db/migrate/20210506093309_create_communications.rb
@@ -1,0 +1,18 @@
+class CreateCommunications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :communications do |t|
+      t.timestamps
+
+      t.references :project,      null: false, index: true, foreign_key: true
+      t.bigint     :parent_id,    null: true,  index: true
+      t.bigint     :sender_id,    null: false, index: true
+      t.bigint     :recipient_id, null: false, index: true
+      t.integer    :medium,       null: false, limit: 1
+      t.datetime   :contacted_at, null: false
+    end
+
+    add_foreign_key :communications, :communications, column: :parent_id
+    add_foreign_key :communications, :users, column: :sender_id
+    add_foreign_key :communications, :users, column: :recipient_id
+  end
+end

--- a/test/fixtures/communications.yml
+++ b/test/fixtures/communications.yml
@@ -1,0 +1,16 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+incoming:
+  project: dummy_project
+  sender: dummy_project_owner
+  recipient: application_manager_one
+  contacted_at: 2021-01-01
+  medium: 3
+
+outgoing:
+  project: dummy_project
+  parent: incoming
+  sender: application_manager_one
+  recipient: dummy_project_owner
+  contacted_at: 2021-01-03
+  medium: 1

--- a/test/integration/communications_test.rb
+++ b/test/integration/communications_test.rb
@@ -1,0 +1,171 @@
+require 'test_helper'
+
+class CommunicationsTest < ActionDispatch::IntegrationTest
+  def setup
+    @project = projects(:test_application)
+    @project.grants.create!(
+      user: users(:application_manager_one),
+      roleable: project_roles(:contributor)
+    )
+
+    sign_in users(:application_manager_one)
+  end
+
+  test 'can view the communications for a project' do
+    communication = create_communication(@project)
+
+    visit project_path(@project)
+
+    within(find_link('Communications')) do
+      assert has_selector?('.badge', text: 1)
+    end
+
+    click_link 'Communications'
+
+    assert has_selector?('table#communications_table')
+
+    within("\#communication_#{communication.id}") do
+      assert has_no_link?('Details')
+      assert has_no_link?('Edit')
+      assert has_link?('Delete')
+      assert has_link?('Comments')
+      assert has_link?('Log Response')
+    end
+  end
+
+  test 'can create a new communication' do
+    visit project_path(@project)
+
+    click_link 'Communications'
+
+    within(find_link('Communications')) do
+      assert has_selector?('.badge', text: 0)
+    end
+
+    within('table#communications_table') do
+      assert has_no_selector?('tr.communication')
+    end
+
+    click_link 'New'
+
+    assert_difference -> { @project.communications.count } do
+      within_modal do
+        select  'Standard User',               from: 'communication[sender_id]'
+        select  'Application Manager One',     from: 'communication[recipient_id]'
+        select  'Email',                       from: 'communication[medium]'
+        fill_in 'communication[contacted_at]', with: Time.zone.today.to_s(:ui)
+
+        click_button 'Save'
+      end
+    end
+
+    within('table#communications_table') do
+      assert has_selector?('tr.communication', count: 1)
+    end
+
+    within(find_link('Communications')) do
+      assert has_selector?('.badge', text: 1)
+    end
+  end
+
+  test 'can create a communication as a response to another' do
+    communication = create_communication(@project)
+
+    visit project_path(@project)
+
+    click_link 'Communications'
+
+    within('table#communications_table') do
+      assert has_no_selector?('td', text: "re: #{communication.id}")
+    end
+
+    within("\#communication_#{communication.id}") do
+      click_link 'Log Response'
+    end
+
+    assert_difference -> { communication.children.count } do
+      within_modal do
+        assert has_select?('communication[sender_id]',    selected: 'Application Manager One')
+        assert has_select?('communication[recipient_id]', selected: 'Standard User')
+
+        select  'Email', from: 'communication[medium]'
+        fill_in 'communication[contacted_at]', with: Time.zone.today.to_s(:ui)
+
+        click_button 'Save'
+      end
+    end
+
+    within('table#communications_table') do
+      assert has_selector?('td', text: "re: #{communication.id}")
+    end
+  end
+
+  test 'cannot create an invalid communication' do
+    visit project_path(@project)
+
+    click_link 'Communications'
+
+    click_link 'New'
+
+    within_modal(remain: true) do
+      assert_no_difference -> { @project.communications.count } do
+        click_button 'Save'
+      end
+    end
+  end
+
+  test 'can delete a communication' do
+    communication = create_communication(@project)
+    selector      = "\#communication_#{communication.id}"
+
+    visit project_path(@project)
+
+    within(find_link('Communications')) do
+      assert has_selector?('.badge', text: 1)
+    end
+
+    click_link 'Communications'
+
+    assert_difference -> { @project.communications.count }, -1 do
+      within(selector) do
+        accept_confirm do
+          click_link 'Delete'
+        end
+      end
+
+      assert has_no_selector?(selector)
+    end
+
+    within(find_link('Communications')) do
+      assert has_selector?('.badge', text: 0)
+    end
+  end
+
+  test 'should display only to application managers' do
+    sign_out :user
+    sign_in @project.owner
+
+    visit project_path(@project)
+
+    assert has_no_selector?('#communications',       visible: :all)
+    assert has_no_selector?('#communications_table', visible: :all)
+    assert has_no_selector?('.communication',        visible: :all)
+
+    visit project_communications_path(@project)
+    assert_equal root_path, current_path
+    # assert has_text?('not authorized') # NOTE: Flakey (!?!?!)
+  end
+
+  private
+
+  def create_communication(project, **attributes)
+    attributes.reverse_merge!(
+      sender:       users(:standard_user),
+      recipient:    users(:application_manager_one),
+      contacted_at: Time.zone.today,
+      medium:       :email
+    )
+
+    project.communications.create!(attributes)
+  end
+end

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -939,6 +939,32 @@ class AbilityTest < ActiveSupport::TestCase
     assert developer.can?           :delete, Delayed::Job
   end
 
+  test 'communications' do
+    user                = users(:standard_user)
+    application_manager = users(:application_manager_one)
+    odr                 = users(:odr_user)
+    administrator       = users(:admin_user)
+    developer           = users(:developer)
+
+    refute user.can?                :read, Communication
+    assert application_manager.can? :read, Communication
+    refute odr.can?                 :read, Communication
+    refute administrator.can?       :read, Communication
+    refute developer.can?           :read, Communication
+
+    refute user.can?                :create, Communication
+    assert application_manager.can? :create, Communication
+    refute odr.can?                 :create, Communication
+    refute administrator.can?       :create, Communication
+    refute developer.can?           :create, Communication
+
+    refute user.can?                :delete, Communication
+    assert application_manager.can? :delete, Communication
+    refute odr.can?                 :delete, Communication
+    refute administrator.can?       :delete, Communication
+    refute developer.can?           :delete, Communication
+  end
+
   private
 
   def create_dataset(options)

--- a/test/models/communication_test.rb
+++ b/test/models/communication_test.rb
@@ -1,0 +1,105 @@
+require 'test_helper'
+
+class CommunicationTest < ActiveSupport::TestCase
+  def setup
+    @communication = communications(:incoming)
+  end
+
+  test 'belongs to a project' do
+    assert_instance_of Project, @communication.project
+  end
+
+  test 'has many children' do
+    assert_instance_of Communication, @communication.children.first
+  end
+
+  test 'belongs to a parent' do
+    assert_instance_of Communication, communications(:outgoing).parent
+  end
+
+  test 'belongs to a sender' do
+    assert_instance_of User, @communication.sender
+  end
+
+  test 'belongs to a recipient' do
+    assert_instance_of User, @communication.recipient
+  end
+
+  test 'is commentable' do
+    assert_includes Communication.included_modules, Commentable
+  end
+
+  test 'is audited' do
+    with_versioning do
+      assert_auditable @communication
+    end
+  end
+
+  test 'is invalid without a project' do
+    @communication.project = nil
+    @communication.valid?
+
+    assert_includes @communication.errors.details[:project], error: :blank
+    assert_raises { @communication.save!(validate: false) }
+  end
+
+  test 'is valid without a parent' do
+    @communication.parent = nil
+    @communication.valid?
+
+    assert_empty @communication.errors.details[:parent]
+    assert_nothing_raised { @communication.save!(validate: false) }
+  end
+
+  test 'is invalid without a sender' do
+    @communication.sender = nil
+    @communication.valid?
+
+    assert_includes @communication.errors.details[:sender], error: :blank
+    assert_raises { @communication.save!(validate: false) }
+  end
+
+  test 'is invalid without a recipient' do
+    @communication.recipient = nil
+    @communication.valid?
+
+    assert_includes @communication.errors.details[:recipient], error: :blank
+    assert_raises { @communication.save!(validate: false) }
+  end
+
+  test 'is invalid without a medium' do
+    @communication.medium = nil
+    @communication.valid?
+
+    assert_includes @communication.errors.details[:medium], error: :blank
+  end
+
+  test 'is invalid without a sent/received date' do
+    @communication.contacted_at = nil
+    @communication.valid?
+
+    assert_includes @communication.errors.details[:contacted_at], error: :blank
+    assert_raises { @communication.save!(validate: false) }
+  end
+
+  test 'is invalid with a future sent/received date' do
+    @communication.contacted_at = 1.day.from_now
+    @communication.valid?
+
+    assert_includes @communication.errors.details[:contacted_at], error: :no_future, no_future: true
+  end
+
+  test 'is invalid with a sent/received date before parent date' do
+    communication = communications(:outgoing)
+    communication.contacted_at = communication.parent_contacted_at - 1.day
+    communication.valid?
+
+    error = {
+      error:      :not_before,
+      not_before: :parent_contacted_at,
+      comparison: 'Parent contacted at'
+    }
+
+    assert_includes communication.errors.details[:contacted_at], error
+  end
+end


### PR DESCRIPTION
This PR adds a resource for capturing/recording when conversation took place between an applicant and an ODR representative (i.e. Application Manager). 

Given that it is presented as an alternative solution to the original request to add a contact date to comments (which are intended as a general purpose solution), and that the ticket lacked any particular specification, this should be treated as a PoC and/or "starter for 10" to establish whether this is going to fit ODR's needs and any further expansion on the idea/approach.