### PR TITLE
Add pdf upload guidance to Amendment page

### DIFF
--- a/app/views/project_amendments/_form.html.erb
+++ b/app/views/project_amendments/_form.html.erb
@@ -18,6 +18,7 @@
 
   <%= form.control_group(:upload) do %>
     <%= form.file_field(:upload, multiple: false, accept: 'application/pdf') %>
+    <%= t('.file_type_guidance') %>
   <% end %>
 
   <%= form.control_group(:labels) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,6 +300,9 @@ en:
     event_field_name: 'event_field_name:'
     lookup_table: 'lookup_table:'
     comments: 'comments:'
+  project_amendments:
+    form:
+      file_type_guidance: File must be a pdf. Convert a Word doc using File then 'Save as Adobe pdf'
   activerecord:
     errors:
       models:


### PR DESCRIPTION
This PR adds text to the amendment form to offer guidance on desired file type.
