### PR TITLE
Fix issue with state name bulk lookup in production

### DIFF
--- a/app/models/workflow/state.rb
+++ b/app/models/workflow/state.rb
@@ -44,7 +44,7 @@ module Workflow
         :"#{project_type.to_lookup_key}.#{lookup_key}"
       end
 
-      translations = I18n.t(context_keys, scope: model_name.i18n_key, default: '')
+      translations = context_keys.map { |key| I18n.t(key, scope: model_name.i18n_key, default: '') }
       translations.uniq!
       translations.reject!(&:blank?)
 


### PR DESCRIPTION
This PR fixes an issue with bulk translation lookup of state names in production environments returning a `translation missing` string, rather than a somewhat expected/desired array of default values.

Exception, for reference:
```
Workflow::State.all.map { |state| state.name(*ProjectType.all) }
Traceback (most recent call last):
        5: from (irb):4
        4: from (irb):4:in `rescue in irb_binding'
        3: from (irb):4:in `map'
        2: from (irb):4:in `block in irb_binding'
        1: from app/models/workflow/state.rb:48:in `name'
NoMethodError (undefined method `uniq!' for "translation missing: en.workflow/state.eoi.approved":String)
```

Curiously...
```
I18n.t([:"project.approved", :"eoi.approved", :"application.approved", :"cas.approved"], scope: Workflow::State.model_name.i18n_key, default: '')
=> ["", "", "", ""]
```