### PR TITLE
Project Filtering Tweaks

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -379,7 +379,7 @@ class ProjectsController < ApplicationController
   end
 
   def search_params
-    params.fetch(:search, default_search_params).permit(
+    params.fetch(:search, {}).permit(
       :name,
       :application_log,
       project_type_id: [],
@@ -391,15 +391,5 @@ class ProjectsController < ApplicationController
         state_id: []
       }
     )
-  end
-
-  def default_search_params
-    return {} unless current_user.application_manager?
-
-    {
-      current_project_state: {
-        state_id: Workflow::State.open.pluck(:id)
-      }
-    }
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -217,12 +217,12 @@ class Project < ApplicationRecord
       filter = arel_table[:application_log].matches("%#{string}%")
 
       return filter unless match ||= string.match(
-        %r(\A(?<head>ODR_(?<fy_start>\d{2,4})_(?<fy_end>\d{2,4})_?)?(?<id>\d+)?(?<tail>/.*)?\z)i
+        %r(\A(?<head>ODR_(?<fy_start>\d{2})(?<fy_end>\d{2})_?)?(?<id>\d+)?(?<tail>/.*)?\z)i
       )
 
       chain = []
-      chain << arel_table[:first_contact_date].gteq("#{match[:fy_start]}-04-01") if match[:fy_start]
-      chain << arel_table[:first_contact_date].lteq("#{match[:fy_end]}-03-31")   if match[:fy_end]
+      chain << arel_table[:first_contact_date].gteq("20#{match[:fy_start]}-04-01") if match[:fy_start]
+      chain << arel_table[:first_contact_date].lteq("20#{match[:fy_end]}-03-31")   if match[:fy_end]
       chain << arel_table[:id].eq(match[:id].to_i) if match[:id]
 
       filter.or(

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -170,7 +170,7 @@ class Project < ApplicationRecord
   DATA_SOURCE_ITEM_NO_CLONE_FIELDS = %w[id project_id project_data_source_item_id].freeze
 
   attr_searchable :name,                  :text_filter
-  attr_searchable :application_log,       :text_filter
+  attr_searchable :application_log,       :application_log_filter # Meh.
   attr_searchable :project_type_id,       :default_filter
   attr_searchable :owner,                 :association_filter, kwargs: true # FIXME: See Searchable
   attr_searchable :current_project_state, :association_filter
@@ -201,6 +201,34 @@ class Project < ApplicationRecord
       base = joins(:current_project_state)
       base.where(assigned_user: user).or(
         base.where(workflow_current_project_states: { assigned_user_id: user })
+      )
+    end
+
+    private
+
+    # Custom search filter.
+    # Legacy data... computed fields... desire to search on magic strings rather than the actual
+    # underyling data...
+    # NOTE: Expect edge cases where this may not produce the anticipated results.
+    def application_log_filter(_field, value)
+      return if value.blank?
+
+      string = value.to_s.strip
+      filter = arel_table[:application_log].matches("%#{string}%")
+
+      return filter unless match ||= string.match(
+        %r(\A(?<head>ODR_(?<fy_start>\d{2,4})_(?<fy_end>\d{2,4})_?)?(?<id>\d+)?(?<tail>/.*)?\z)i
+      )
+
+      chain = []
+      chain << arel_table[:first_contact_date].gteq("#{match[:fy_start]}-04-01") if match[:fy_start]
+      chain << arel_table[:first_contact_date].lteq("#{match[:fy_end]}-03-31")   if match[:fy_end]
+      chain << arel_table[:id].eq(match[:id].to_i) if match[:id]
+
+      filter.or(
+        Arel::Nodes::Grouping.new(
+          chain.reduce(chain.shift) { |node, predicate| node.and(predicate) }
+        )
       )
     end
   end

--- a/app/views/projects/_search_form.html.erb
+++ b/app/views/projects/_search_form.html.erb
@@ -31,7 +31,7 @@
   <%= form.fields_for :owner do |sub_form| %>
     <fieldset>
       <legend>
-        <a href="#project_owner_filters" class="btn btn-default btn-xs" data-toggle="collapse">
+        <a href="#project_owner_filters" class="btn btn-default btn-xs collapsed" data-toggle="collapse">
           <%= bootstrap_icon_tag('eye-open') %>
           <%= bootstrap_icon_tag('eye-close') %>
         </a>
@@ -54,7 +54,7 @@
 
   <fieldset data-controller="checkbox-select-all">
     <legend>
-      <a href="#project_type_filters" class="btn btn-default btn-xs" data-toggle="collapse">
+      <a href="#project_type_filters" class="btn btn-default btn-xs collapsed" data-toggle="collapse">
         <%= bootstrap_icon_tag('eye-open') %>
         <%= bootstrap_icon_tag('eye-close') %>
       </a>
@@ -84,7 +84,7 @@
   <%= form.fields_for :current_project_state do |sub_form| %>
     <fieldset data-controller="checkbox-select-all">
       <legend>
-        <a href="#project_state_filters" class="btn btn-default btn-xs" data-toggle="collapse">
+        <a href="#project_state_filters" class="btn btn-default btn-xs collapsed" data-toggle="collapse">
           <%= bootstrap_icon_tag('eye-open') %>
           <%= bootstrap_icon_tag('eye-close') %>
         </a>

--- a/app/views/projects/_search_form.html.erb
+++ b/app/views/projects/_search_form.html.erb
@@ -35,7 +35,7 @@
           <%= bootstrap_icon_tag('eye-open') %>
           <%= bootstrap_icon_tag('eye-close') %>
         </a>
-        Project Owner
+        <%= Project.human_attribute_name(:owner) %>
       </legend>
 
       <div class="collapse" id="project_owner_filters">

--- a/app/views/projects/_search_form.html.erb
+++ b/app/views/projects/_search_form.html.erb
@@ -8,7 +8,7 @@
 <%= form_with url: url, scope: :search, method: :get, id: 'project_search_form' do |form| %>
   <fieldset>
     <legend>
-      <a href="#project_filters" class="btn btn-default btn-xs" data-toggle="collapse">
+      <a href="#project_filters" class="btn btn-default btn-xs" data-toggle="collapse" expanded="true" aria-controls="project_filters">
         <%= bootstrap_icon_tag('eye-open') %>
         <%= bootstrap_icon_tag('eye-close') %>
       </a>
@@ -31,7 +31,7 @@
   <%= form.fields_for :owner do |sub_form| %>
     <fieldset>
       <legend>
-        <a href="#project_owner_filters" class="btn btn-default btn-xs collapsed" data-toggle="collapse">
+        <a href="#project_owner_filters" class="btn btn-default btn-xs collapsed" data-toggle="collapse" expanded="false" aria-controls="project_owner_filters">
           <%= bootstrap_icon_tag('eye-open') %>
           <%= bootstrap_icon_tag('eye-close') %>
         </a>
@@ -54,7 +54,7 @@
 
   <fieldset data-controller="checkbox-select-all">
     <legend>
-      <a href="#project_type_filters" class="btn btn-default btn-xs collapsed" data-toggle="collapse">
+      <a href="#project_type_filters" class="btn btn-default btn-xs collapsed" data-toggle="collapse" expanded="false" aria-controls="project_type_filters">
         <%= bootstrap_icon_tag('eye-open') %>
         <%= bootstrap_icon_tag('eye-close') %>
       </a>
@@ -84,7 +84,7 @@
   <%= form.fields_for :current_project_state do |sub_form| %>
     <fieldset data-controller="checkbox-select-all">
       <legend>
-        <a href="#project_state_filters" class="btn btn-default btn-xs collapsed" data-toggle="collapse">
+        <a href="#project_state_filters" class="btn btn-default btn-xs collapsed" data-toggle="collapse" expanded="false" aria-controls="project_state_filters">
           <%= bootstrap_icon_tag('eye-open') %>
           <%= bootstrap_icon_tag('eye-close') %>
         </a>

--- a/app/views/projects/_search_layout.html.erb
+++ b/app/views/projects/_search_layout.html.erb
@@ -2,10 +2,19 @@
   <div class="col-md-12">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h4 class="panel-title">Search</h4>
+        <h4 class="panel-title">
+          <button type="button" class="btn btn-primary btn-xs collapsed" data-toggle="collapse" data-target="#project_search_content" aria-expanded="false" aria-controls="project_search_content">
+            <%= bootstrap_icon_tag('eye-open') %>
+            <%= bootstrap_icon_tag('eye-close') %>
+          </button>
+          Search
+        </h4>
+
       </div>
-      <div class="panel-body">
-        <%= content_for(:search) %>
+      <div class="collapse" id="project_search_content">
+        <div class="panel-body">
+          <%= content_for(:search) %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/projects/_search_layout.html.erb
+++ b/app/views/projects/_search_layout.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-md-3">
+  <div class="col-md-12">
     <div class="panel panel-default">
       <div class="panel-heading">
         <h4 class="panel-title">Search</h4>
@@ -9,7 +9,7 @@
       </div>
     </div>
   </div>
-  <div class="col-md-9">
+  <div class="col-md-12">
     <%= yield %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -338,6 +338,7 @@ en:
       data_privacy_impact_assessment:
         one: DPIA
         other: DPIAs
+      workflow/state: Status
     attributes:
       cas_application_fields:
         firstname: First name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -362,6 +362,8 @@ en:
       project:
         name: Project Title
         assigned_user: Application Manager
+        owner: Applicant
+        application_log: ODR Ref
       data_privacy_impact_assessment:
         ig_toolkit_version: Year of IG assessment status
         ig_score: IG score

--- a/test/integration/project_dashboard_test.rb
+++ b/test/integration/project_dashboard_test.rb
@@ -24,7 +24,7 @@ class ProjectDashboardTest < ActionDispatch::IntegrationTest
     assert has_content?('All Projects')
     assert has_no_content?('Assigned Projects')
 
-    assert has_selector?('#project_search_form')
+    assert has_selector?('#project_search_form', visible: false)
 
     within('#my-projects') do
       assert has_content?(eoi_project.id.to_s)
@@ -64,7 +64,7 @@ class ProjectDashboardTest < ActionDispatch::IntegrationTest
     assert has_content?('All Projects')
     assert has_no_content?('Assigned Projects')
 
-    assert has_selector?('#project_search_form')
+    assert has_selector?('#project_search_form', visible: false)
 
     within('#my-projects') do
       assert has_content?(mbis_project.id.to_s)

--- a/test/integration/project_search_test.rb
+++ b/test/integration/project_search_test.rb
@@ -12,6 +12,8 @@ class ProjectSearchTest < ActionDispatch::IntegrationTest
   end
 
   test 'can search by project name' do
+    expand_search_form
+
     within('#project_search_form') do
       fill_in 'search[name]', with: 'YARP'
       click_button 'Search'
@@ -26,6 +28,8 @@ class ProjectSearchTest < ActionDispatch::IntegrationTest
   end
 
   test 'can search by application_ref' do
+    expand_search_form
+
     within('#project_search_form') do
       fill_in 'search[application_log]', with: 'search.ref.2'
       click_button 'Search'
@@ -38,6 +42,8 @@ class ProjectSearchTest < ActionDispatch::IntegrationTest
   end
 
   test 'can search by project type' do
+    expand_search_form
+
     within('#project_search_form') do
       click_link(href: '#project_type_filters')
 
@@ -57,6 +63,8 @@ class ProjectSearchTest < ActionDispatch::IntegrationTest
 
   test 'can search by project owner' do
     user = users(:standard_user1)
+
+    expand_search_form
 
     within('#project_search_form') do
       click_link(href: '#project_owner_filters')
@@ -80,6 +88,8 @@ class ProjectSearchTest < ActionDispatch::IntegrationTest
       project_state.save!(validate: false)
     end
 
+    expand_search_form
+
     within('#project_search_form') do
       click_link(href: '#project_state_filters')
 
@@ -98,6 +108,8 @@ class ProjectSearchTest < ActionDispatch::IntegrationTest
   end
 
   test 'filters are applied cumulatively' do
+    expand_search_form
+
     within('#project_search_form') do
       fill_in 'Project Title', with: 'YARP'
 
@@ -119,6 +131,8 @@ class ProjectSearchTest < ActionDispatch::IntegrationTest
 
   test 'filters can be a little fuzzy and case insensitive' do
     user = users(:standard_user1)
+
+    expand_search_form
 
     within('#project_search_form') do
       fill_in 'search[name]', with: 'ar'
@@ -142,6 +156,8 @@ class ProjectSearchTest < ActionDispatch::IntegrationTest
     sign_in users(:application_manager_one)
 
     visit dashboard_projects_path
+
+    expand_search_form
 
     within('#project_search_form') do
       fill_in 'search[name]', with: 'narp'
@@ -176,6 +192,8 @@ class ProjectSearchTest < ActionDispatch::IntegrationTest
 
     visit dashboard_projects_path
 
+    expand_search_form
+
     assert has_no_content? 'My Projects'
     assert has_content? 'Assigned Projects'
     assert has_content? 'Unassigned Projects'
@@ -194,6 +212,10 @@ class ProjectSearchTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  def expand_search_form
+    find('[data-target="#project_search_content"].collapsed').click
+  end
 
   def uncheck_all
     all('input[type="checkbox"]').each(&:uncheck)


### PR DESCRIPTION
This PR introduces additional updates that have come about following testing feedback on project filtering.

- Filter id/first_contact_date by decomposed magic reference strings [#26475]
- Use ODR preferred attribute names on search form [#26475]
- Restore ODR ref searching over application_log/id/first_contact_date [#26475]
- Reposition search form at top of page [#26475]
- Removal of default search criteria for ODR users [#26496]
