### PR TITLE
Workflow position email notifications

### DIFF
--- a/app/controllers/concerns/workflow/controller.rb
+++ b/app/controllers/concerns/workflow/controller.rb
@@ -15,6 +15,7 @@ module Workflow
       with_options only: :transition do
         after_action :allocate_project
         around_action :notify_temporally_assigned_user
+        after_action  :send_transition_email
       end
     end
 
@@ -62,6 +63,29 @@ module Workflow
         @state.assignable_users.where.not(id: current_user).find_by(id: id)
     end
 
+    def send_transition_email
+      return unless @project.current_state == @state
+
+      @project.users.find_each do |user|
+        next if user == current_user # Does the user performing the transition need notifying?
+
+        kwargs = { project: @project, user: user, current_user: current_user }
+
+        # TODO: Is there a more elegant way of handling this? Like determining the correct locale
+        # from a project role?
+        if user == @project.assigned_user
+          kwargs[:comments] = extract_comment_from_params
+          kwargs[:locale]   = :'en-odr'
+        elsif user == @project.temporally_assigned_user
+          kwargs[:comments] = extract_comment_from_params
+        end
+
+        # NOTE: Returns NullMail if `state_changed` returns via guard clause, so no need for
+        # safe navigation operator...
+        ProjectsMailer.with(**kwargs).state_changed.deliver_later
+      end
+    end
+
     def notify_temporally_assigned_user
       initial_project_state = @project.current_project_state
       yield
@@ -74,7 +98,7 @@ module Workflow
         project:     @project,
         assigned_to: temporally_assigned_user,
         assigned_by: current_user,
-        comments:    comment_params.dig(:comments_attributes, '0', :body)
+        comments:    extract_comment_from_params
       ).project_assignment.deliver_later
     end
 
@@ -92,6 +116,10 @@ module Workflow
         applicable_to(@project.project_type).
         find_by(next_state: @state)&.
         requires_yubikey?
+    end
+
+    def extract_comment_from_params
+      comment_params.dig(:comments_attributes, '0', :body)
     end
   end
 end

--- a/app/mailers/concerns/workflow/mail.rb
+++ b/app/mailers/concerns/workflow/mail.rb
@@ -47,6 +47,18 @@ module Workflow
     end
     alias transitioned_to_rejected transitioned
 
+    def application_transitioned_to_rejected
+      @interpolations = default_interpolations.merge!(
+        current_user:   @current_user.full_name,
+        closure_reason: @project.closure_reason.value
+      )
+
+      transition_email do |format|
+        render_default_template(format)
+      end
+    end
+    alias eoi_transitioned_to_rejected application_transitioned_to_rejected
+
     private
 
     def load_user

--- a/app/mailers/concerns/workflow/mail.rb
+++ b/app/mailers/concerns/workflow/mail.rb
@@ -37,7 +37,7 @@ module Workflow
       # appropriately) and set a variable for use as a translation lookup prefix; the intent is
       # that it allows better reuse of the default template, whilst still having dynamic
       # translation content.
-      @key = __callee__
+      @i18n_prefix = __callee__
 
       @interpolations = default_interpolations
 
@@ -76,7 +76,7 @@ module Workflow
 
     def transition_email(**options, &block)
       # For translation lookup purposes. If not already set, infer from the calling method.
-      @key ||= caller_locations.first.label
+      @i18n_prefix ||= caller_locations.first.label
 
       subject = t(
         :subject,

--- a/app/mailers/concerns/workflow/mail.rb
+++ b/app/mailers/concerns/workflow/mail.rb
@@ -33,12 +33,19 @@ module Workflow
 
     # A default/generic message to send when any project type changes to any state.
     def transitioned
+      # For translation lookup purposes. Capture the current method name (handling aliases
+      # appropriately) and set a variable for use as a translation lookup prefix; the intent is
+      # that it allows better reuse of the default template, whilst still having dynamic
+      # translation content.
+      @key = __callee__
+
       @interpolations = default_interpolations
 
       transition_email do |format|
         render_default_template(format)
       end
     end
+    alias transitioned_to_rejected transitioned
 
     private
 
@@ -68,7 +75,9 @@ module Workflow
     end
 
     def transition_email(**options, &block)
-      @key    = caller_locations(1, 1).first.label # for translation lookup purposes
+      # For translation lookup purposes. If not already set, infer from the calling method.
+      @key ||= caller_locations.first.label
+
       subject = t(
         :subject,
         scope:   [:projects_mailer],

--- a/app/mailers/concerns/workflow/mail.rb
+++ b/app/mailers/concerns/workflow/mail.rb
@@ -85,7 +85,17 @@ module Workflow
         type:    @project.project_type_name
       )
 
-      mail(options.merge(to: @user.email, subject: subject), &block)
+      localize_mail(params[:locale]) do
+        mail(options.merge(to: @user.email, subject: subject), &block)
+      end
+    end
+
+    # Leveraging locales as a means to present varying content to different audiences, for the
+    # (debatably) same email. Inspired by:
+    # https://guides.rubyonrails.org/action_view_overview.html#localized-views
+    # https://guides.rubyonrails.org/i18n.html#localized-views
+    def localize_mail(locale = I18n.default_locale, &block)
+      I18n.with_locale(locale, &block)
     end
   end
 end

--- a/app/mailers/concerns/workflow/mail.rb
+++ b/app/mailers/concerns/workflow/mail.rb
@@ -1,0 +1,82 @@
+module Workflow
+  # Contains mailer logic for generating emails about changes to a `project`s `state`.
+  module Mail
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :load_user
+      before_action :load_current_user
+      before_action :load_comments
+    end
+
+    # Acts as a wrapper around other transition related emails, automagically determining the
+    # correct mail to send based on a project's type and state, for convenience.
+    # NOTE: The generic `:transition` email/option is currently excluded because without a
+    # mechanism for users to manage what kind of status updates they're interested in, this could
+    # have the potential to be a bit spammy (especially considering pre-existing behaviour of
+    # mailing all users associated with the project).
+    def state_changed
+      state_key        = @project.current_state.to_lookup_key
+      project_type_key = @project.project_type.to_lookup_key
+
+      methods = [
+        :"#{project_type_key}_transitioned_to_#{state_key}",
+        :"transitioned_to_#{state_key}",
+        :"#{project_type_key}_transitioned"
+        # :transitioned
+      ]
+
+      method = methods.find { |method_name| respond_to?(method_name) }
+
+      public_send(method) if method
+    end
+
+    # A default/generic message to send when any project type changes to any state.
+    def transitioned
+      @interpolations = default_interpolations
+
+      transition_email do |format|
+        render_default_template(format)
+      end
+    end
+
+    private
+
+    def load_user
+      @user = params[:user]
+    end
+
+    def load_current_user
+      @current_user = params[:current_user]
+    end
+
+    def load_comments
+      @comments = params[:comments]
+    end
+
+    def default_interpolations
+      {
+        type:  @project.project_type_name,
+        state: @project.current_state_name,
+        title: @project.name
+      }
+    end
+
+    def render_default_template(format)
+      format.html { render :transitioned }
+      format.text { render :transitioned }
+    end
+
+    def transition_email(**options, &block)
+      @key    = caller_locations(1, 1).first.label # for translation lookup purposes
+      subject = t(
+        :subject,
+        scope:   [:projects_mailer],
+        default: [:'transitioned.subject', action_name.humanize],
+        type:    @project.project_type_name
+      )
+
+      mail(options.merge(to: @user.email, subject: subject), &block)
+    end
+  end
+end

--- a/app/mailers/projects_mailer.rb
+++ b/app/mailers/projects_mailer.rb
@@ -1,5 +1,7 @@
 # Sends emails regarding Project related activity
 class ProjectsMailer < ApplicationMailer
+  include Workflow::Mail
+
   before_action :load_project
 
   def project_assignment

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -397,7 +397,7 @@ class Project < ApplicationRecord
   def odr_rejected_notification
     return unless template ||= CONTENT_TEMPLATES.dig('email_project_odr_approval_decision', 'body')
 
-    Notification.create! do |notification|
+    Notification.create!(generate_mail: false) do |notification|
       notification.title      = "#{name} - Rejected"
       notification.body       = format(template, project: name, status: current_state.id)
       notification.project_id = id

--- a/app/models/workflow/project_state.rb
+++ b/app/models/workflow/project_state.rb
@@ -33,6 +33,11 @@ module Workflow
     delegate :assigned_user, :assigning_user, to: :current_assignment, allow_nil: true
     delegate :full_name, to: :assigned_user,  prefix: true, allow_nil: true
     delegate :full_name, to: :assigning_user, prefix: true, allow_nil: true
+    delegate :project_type, to: :project
+
+    def state_name
+      state.name(project_type)
+    end
 
     def assignable_users
       return User.none unless state && project

--- a/app/models/workflow/state.rb
+++ b/app/models/workflow/state.rb
@@ -44,7 +44,7 @@ module Workflow
         :"#{project_type.to_lookup_key}.#{lookup_key}"
       end
 
-      translations = I18n.t(context_keys, scope: model_name.i18n_key, default: '')
+      translations = context_keys.map { |key| I18n.t(key, scope: model_name.i18n_key, default: '') }
       translations.uniq!
       translations.reject!(&:blank?)
 

--- a/app/views/projects_mailer/transitioned.html.erb
+++ b/app/views/projects_mailer/transitioned.html.erb
@@ -2,10 +2,10 @@
   interpolations = @interpolations.merge(scope: :projects_mailer)
 %>
 
-<h1><%= t(:"#{@key}.heading", **interpolations.merge(default: :'transitioned.heading')) %></h1>
+<h1><%= t(:"#{@i18n_prefix}.heading", **interpolations.merge(default: :'transitioned.heading')) %></h1>
 <hr />
 
-<%= t(:"#{@key}.body_html", **interpolations.merge(default: [:"#{@key}.body", :'transitioned.body_html', :'transitioned.body'])) %>
+<%= t(:"#{@i18n_prefix}.body_html", **interpolations.merge(default: [:"#{@i18n_prefix}.body", :'transitioned.body_html', :'transitioned.body'])) %>
 
 <% if @comments %>
   <blockquote>

--- a/app/views/projects_mailer/transitioned.html.erb
+++ b/app/views/projects_mailer/transitioned.html.erb
@@ -1,0 +1,24 @@
+<%
+  interpolations = @interpolations.merge(scope: :projects_mailer)
+%>
+
+<h1><%= t(:"#{@key}.heading", **interpolations.merge(default: :'transitioned.heading')) %></h1>
+<hr />
+
+<%= t(:"#{@key}.body_html", **interpolations.merge(default: [:"#{@key}.body", :'transitioned.body_html', :'transitioned.body'])) %>
+
+<% if @comments %>
+  <blockquote>
+    <q><%= @comments %></q>
+    <footer>— <i><%= @current_user.full_name %></i></footer>
+  </blockquote>
+  <br />
+<% end %>
+
+<section>
+  <h2 style="font-size: 1.2em;">Project Details:</h2>
+  <%= render 'project_details', project: @project %>
+</section>
+
+<br />
+<%= render 'footer' %>

--- a/app/views/projects_mailer/transitioned.text.erb
+++ b/app/views/projects_mailer/transitioned.text.erb
@@ -2,9 +2,9 @@
   interpolations = @interpolations.merge(scope: :projects_mailer)
 %>
 
-##### <%= t(:"#{@key}.heading", **interpolations.merge(default: :'transitioned.heading')) %> #####
+##### <%= t(:"#{@i18n_prefix}.heading", **interpolations.merge(default: :'transitioned.heading')) %> #####
 
-<%= t(:"#{@key}.body", **interpolations.merge(default: [:"#{@key}.body", :'transitioned.body'])) %>
+<%= t(:"#{@i18n_prefix}.body", **interpolations.merge(default: [:"#{@i18n_prefix}.body", :'transitioned.body'])) %>
 
 <% if @comments %>
 "<%= @comments %>"

--- a/app/views/projects_mailer/transitioned.text.erb
+++ b/app/views/projects_mailer/transitioned.text.erb
@@ -1,0 +1,18 @@
+<%
+  interpolations = @interpolations.merge(scope: :projects_mailer)
+%>
+
+##### <%= t(:"#{@key}.heading", **interpolations.merge(default: :'transitioned.heading')) %> #####
+
+<%= t(:"#{@key}.body", **interpolations.merge(default: [:"#{@key}.body", :'transitioned.body'])) %>
+
+<% if @comments %>
+"<%= @comments %>"
+— <%= @current_user.full_name %>
+<% end %>
+
+### Project Details ###
+
+<%= render 'project_details', project: @project %>
+
+<%= render 'footer' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,9 @@ module Mbis
     config.active_job.queue_adapter = :delayed_job
 
     config.action_view.form_with_generates_ids = true
+
+    config.i18n.default_locale    = :en
+    config.i18n.fallbacks         = true
+    config.i18n.available_locales = %i[en en-odr]
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  # config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -434,3 +434,8 @@ en:
       body_html: >
         <p>The status for the project entitled <q><cite>%{title}</cite></q> has changed to <b><q>%{state}</q></b>.</p>
       body: The status for the project entitled "%{title}" has changed to "%{state}".
+    transitioned_to_rejected:
+      body_html: >
+        <p><q><cite>%{title}</cite></q> has been reviewed by ODR and set to a status of <q>%{state}</q></p>
+      body: >
+        "%{title}" has been reviewed by ODR and set to a status of "%{state}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -434,8 +434,10 @@ en:
       body_html: >
         <p>The status for the project entitled <q><cite>%{title}</cite></q> has changed to <b><q>%{state}</q></b>.</p>
       body: The status for the project entitled "%{title}" has changed to "%{state}".
-    transitioned_to_rejected:
+    transitioned_to_rejected: &transitioned_to_rejected
       body_html: >
         <p><q><cite>%{title}</cite></q> has been reviewed by ODR and set to a status of <q>%{state}</q></p>
       body: >
         "%{title}" has been reviewed by ODR and set to a status of "%{state}"
+    application_transitioned_to_rejected:
+      <<: *transitioned_to_rejected

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -428,3 +428,9 @@ en:
         body: A DPIA for this project has been rejected by %{assigner}.
       dpia_moderation:
         body: A project has been sent to you for senior application manager moderation by %{assigner}.
+    transitioned:
+      subject: "%{type} Status Update"
+      heading: "%{type} Status Update"
+      body_html: >
+        <p>The status for the project entitled <q><cite>%{title}</cite></q> has changed to <b><q>%{state}</q></b>.</p>
+      body: The status for the project entitled "%{title}" has changed to "%{state}".

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,3 +441,14 @@ en:
         "%{title}" has been reviewed by ODR and set to a status of "%{state}"
     application_transitioned_to_rejected:
       <<: *transitioned_to_rejected
+
+en-odr:
+  projects_mailer:
+    application_transitioned_to_rejected:
+      body_html: >
+        <p>A project you are managing has been closed by %{current_user}.</p>
+        <p><b>Closure reason:</b> %{closure_reason}</p>
+      body: |
+        A project you are managing has been closed by %{current_user}.
+
+        Closure reason: %{closure_reason}

--- a/test/fixtures/lookups/closure_reason.yml
+++ b/test/fixtures/lookups/closure_reason.yml
@@ -1,7 +1,6 @@
 # Created by `bin/rails lookup:create_fixture[ClosureReason]` at 2019-08-09 12:13:20 UTC
 ---
-1:
-  id: 1
+unresponsive:
   value: Unresponsive
   created_at: !ruby/object:ActiveSupport::TimeWithZone
     utc: &1 2019-08-06 12:56:41.533118000 Z
@@ -122,4 +121,3 @@
     utc: &23 2019-08-06 12:56:41.547593000 Z
     zone: *2
     time: *23
-

--- a/test/integration/application_project_test.rb
+++ b/test/integration/application_project_test.rb
@@ -336,15 +336,13 @@ class ApplicationProjectTest < ActionDispatch::IntegrationTest
   end
 
   def assert_assignment_email(assignee:, assigner:, comments: nil)
-    assert_enqueued_emails 1 do
-      yield
+    yield
 
-      assert_enqueued_email_with ProjectsMailer, :project_assignment, args: {
-        project:     @project.reload,
-        assigned_to: assignee,
-        assigned_by: assigner,
-        comments:    comments
-      }
-    end
+    assert_enqueued_email_with ProjectsMailer, :project_assignment, args: {
+      project:     @project.reload,
+      assigned_to: assignee,
+      assigned_by: assigner,
+      comments:    comments
+    }
   end
 end

--- a/test/integration/workflow_test.rb
+++ b/test/integration/workflow_test.rb
@@ -54,4 +54,41 @@ class WorkflowTest < ActionDispatch::IntegrationTest
       assert has_no_text? 'Authentication Required'
     end
   end
+
+  test 'state changes trigger email notifications' do
+    project    = create_project
+    user       = project.owner
+    other_user = users(:standard_user1)
+
+    # The factory user doesn't seem to have an appropriate team applicant role?
+    user.grants.create!(roleable: team_roles(:mbis_applicant), team: project.team)
+
+    project.grants.create!(user: other_user, roleable: project_roles(:contributor))
+
+    sign_in user
+
+    visit project_path(project)
+
+    within('#project_header') do
+      accept_confirm do
+        click_button 'Submit for Delegate Approval'
+      end
+    end
+
+    assert has_no_button?('Submit for Delegate Approval')
+
+    assert_enqueued_email_with ProjectsMailer, :state_changed, args: {
+      project:      project,
+      user:         other_user,
+      current_user: user
+    }
+
+    # Sends to all project users, except user that initiated the transition (and possibly some
+    # other edge case exceptions, but shhhh...)
+    refute_enqueued_email_with ProjectsMailer, :state_changed, args: {
+      project:      project,
+      user:         project.owner,
+      current_user: user
+    }
+  end
 end

--- a/test/mailers/concerns/workflow/mail_test.rb
+++ b/test/mailers/concerns/workflow/mail_test.rb
@@ -68,7 +68,7 @@ module Workflow
       ).state_changed.deliver_now
     end
 
-    test 'state changed email with state specific shandler' do
+    test 'state changed email with state specific handler' do
       project = projects(:dummy_project)
       state   = project.current_state.to_lookup_key
 

--- a/test/mailers/concerns/workflow/mail_test.rb
+++ b/test/mailers/concerns/workflow/mail_test.rb
@@ -1,0 +1,103 @@
+require 'test_helper'
+
+module Workflow
+  # Test the Workflow::Mail concern.
+  class MailTest < ActionMailer::TestCase
+    tests :projects_mailer
+
+    test 'default transitioned email' do
+      project = projects(:dummy_project)
+
+      email = ProjectsMailer.with(
+        project:      project,
+        user:         project.owner,
+        current_user: project.owner
+      ).transitioned
+
+      assert_emails(1) { email.deliver_now }
+
+      assert_equal [project.owner.email], email.to
+      assert_equal 'Dummy Status Update', email.subject
+      assert_match 'Dummy Status Update', email.encoded
+      assert_match(<<~STR.squish, email.encoded)
+        The status for the project entitled "#{project.name}" has changed
+        to "#{project.current_state_name}"
+      STR
+      assert_match 'Project Details', email.encoded
+      assert_match %r{http://[^/]+/projects/#{project.id}}, email.encoded
+    end
+
+    test 'default transition email, with comment' do
+      project = projects(:dummy_project)
+
+      email = ProjectsMailer.with(
+        project:      project,
+        user:         project.owner,
+        current_user: project.owner,
+        comments:     'RAWR!'
+      ).transitioned
+
+      assert_emails(1) { email.deliver_now }
+
+      assert_match 'RAWR!', email.encoded
+    end
+
+    test 'state changed email with no specific handler' do
+      project = projects(:dummy_project)
+
+      # ... because currently disabled
+      ProjectsMailer.any_instance.expects(:transitioned).never
+
+      ProjectsMailer.with(
+        project:      project,
+        user:         project.owner,
+        current_user: project.owner
+      ).state_changed.deliver_now
+    end
+
+    test 'state changed email with project type specific handler' do
+      project = projects(:dummy_project)
+
+      ProjectsMailer.any_instance.expects(:transitioned).never
+      ProjectsMailer.any_instance.expects(:dummy_transitioned)
+
+      ProjectsMailer.with(
+        project:      project,
+        user:         project.owner,
+        current_user: project.owner
+      ).state_changed.deliver_now
+    end
+
+    test 'state changed email with state specific shandler' do
+      project = projects(:dummy_project)
+      state   = project.current_state.to_lookup_key
+
+      ProjectsMailer.any_instance.expects(:transitioned).never
+      ProjectsMailer.any_instance.expects(:dummy_transitioned).never
+      ProjectsMailer.any_instance.expects(:"transitioned_to_#{state}")
+
+      ProjectsMailer.with(
+        project:      project,
+        user:         project.owner,
+        current_user: project.owner
+      ).state_changed.deliver_now
+    end
+
+    test 'state changed email with project type and state specific shandler' do
+      project = projects(:dummy_project)
+      state   = project.current_state.to_lookup_key
+      type    = project.project_type.to_lookup_key
+
+      ProjectsMailer.any_instance.expects(:transitioned).never
+      ProjectsMailer.any_instance.expects(:dummy_transitioned).never
+      ProjectsMailer.any_instance.expects(:"transitioned_to_#{state}").never
+      ProjectsMailer.any_instance.expects(:"#{type}_transitioned_to_#{state}")
+
+      ProjectsMailer.with(
+        project:      project,
+        user:         project.owner,
+        current_user: project.owner
+      ).state_changed.deliver_now
+    end
+  end
+end

--- a/test/mailers/previews/projects_mailer_preview.rb
+++ b/test/mailers/previews/projects_mailer_preview.rb
@@ -33,4 +33,21 @@ class ProjectsMailerPreview < ActionMailer::Preview
       current_user: project.owner
     ).transitioned
   end
+
+  def transitioned_to_rejected
+    project =
+      Project.joins(:project_type, :current_state).
+      merge(ProjectType.application).
+      merge(Workflow::State.where(id: 'REJECTED')).
+      order(:id).
+      limit(1).
+      first
+
+    ProjectsMailer.with(
+      project:      project,
+      user:         project.owner,
+      current_user: project.assigned_user,
+      comments:     'RAWR!'
+    ).state_changed
+  end
 end

--- a/test/mailers/previews/projects_mailer_preview.rb
+++ b/test/mailers/previews/projects_mailer_preview.rb
@@ -17,4 +17,20 @@ class ProjectsMailerPreview < ActionMailer::Preview
 
     ProjectsMailer.with(project: project).project_awaiting_assignment
   end
+
+  def transitioned
+    project =
+      Project.joins(:project_type, :current_state).
+      merge(ProjectType.application).
+      merge(Workflow::State.where(id: 'SUBMITTED')).
+      order(:id).
+      limit(1).
+      first
+
+    ProjectsMailer.with(
+      project:      project,
+      user:         project.owner,
+      current_user: project.owner
+    ).transitioned
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -492,9 +492,9 @@ class ProjectTest < ActiveSupport::TestCase
     project.reload
 
     assert_difference 'Notification.count', 3 do
-      assert_emails 3 do
+      assert_emails 2 do
         project.odr_approval_needed_notification
-        project.odr_rejected_notification
+        project.odr_rejected_notification # Does not generate mail via Notification; now handled by a mailer
         project.odr_approved_notification
       end
     end


### PR DESCRIPTION
This PR somewhat indirectly addressess the request for different mail content/terminology to be used when an application manager receives notification about a project being closed (Plan.IO 27280).

I've approached this from a slightly more abstracted perspective and the bulk of the PR is a lot of groundwork and foundations for sending emails to interested parties when a project moves to *any* state (and in a way that helps to decouple emails from `Notification`s and remove side effect logic from the persistence layer).

The use of localisation over branching logic feels like a nice touch, and could help in the long run when things like views diverge to the point where having a single template feels constraining and hurts readability (from e.g. excessive branching), but I'm slightly concious about it...
- Is it correct and consistent in terms of favoured approach to these problems within the team and our other codebases? (although I know we've done so on at least one other project, to great effect).
- Accessibility to the next dev; can they just pick it up and run, or will they get bogged down in layers of indirection/abstraction?
- Am I using a scalpel to spread butter?

So, thoughts very much welcome on this one!


Commits:
- Add `project_state_name` delegate.
- Add framework for sending project state change emails
- Replicate mail generated from rejected Notification
- Boyscouting - clearer variable names
- Backport translations fix for state names
- Use localisation for varying email content for different target audiences
- Add application/eoi specific rejected email
- Add an ODR specific version of the project rejected email
- Wire up post transition email notifications
- Project rejected `Notification`s should not generate email
- Do not email about state changes under certain condiftions
