### PR TITLE
Fix issue with duration datum not importing [21815]

### DIFF
--- a/app/controllers/projects/imports_controller.rb
+++ b/app/controllers/projects/imports_controller.rb
@@ -83,7 +83,7 @@ module Projects
 
     def each_acroform_attribute
       pdf_file.acroform_data.each do |attribute, value|
-        attribute = attribute.dup.to_s.underscore
+        attribute = attribute.dup.to_s.underscore.tr(' ', '_')
         attribute.prepend('article_') if attribute =~ /\A\d\w\z/
 
         value = value.dup.presence

--- a/app/facades/pdf_application_facade.rb
+++ b/app/facades/pdf_application_facade.rb
@@ -100,6 +100,7 @@ class PdfApplicationFacade
   alias_attribute :rec_reference,               :ethics_approval_nrec_ref
   alias_attribute :rec_name,                    :ethics_approval_nrec_name
   alias_attribute :informed_consent_attach,     :informed_patient_consent
+  alias_attribute :project_duration,            :duration
 
   class << self
     def perform_metaprogamming


### PR DESCRIPTION
As per title. the issue was being caused by the following:
- PDF field name not camel case
- PDF field name contained space(s)
- PDF field did not match the database column name
