### PR TITLE
Allow DPIA's, Contracts and Releases to relate to project or amendment reference [26790]

### DIFF
--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -55,6 +55,7 @@ class ContractsController < ApplicationController
   def resource_params
     params.require(:contract).permit(
       %i[
+        referent_gid
         contract_version
         contract_sent_date
         contract_received_date

--- a/app/controllers/contracts_controller.rb
+++ b/app/controllers/contracts_controller.rb
@@ -1,7 +1,7 @@
 # RESTfully manages `Contract`s
 class ContractsController < ApplicationController
   load_and_authorize_resource :project
-  load_and_authorize_resource through: :project, shallow: true
+  load_and_authorize_resource through: :project, shallow: true, through_association: :global_contracts
 
   # We'll handle this one manually...
   skip_authorize_resource only: %i[download]

--- a/app/controllers/data_privacy_impact_assessments_controller.rb
+++ b/app/controllers/data_privacy_impact_assessments_controller.rb
@@ -2,10 +2,10 @@
 class DataPrivacyImpactAssessmentsController < ApplicationController
   load_and_authorize_resource :project
   load_and_authorize_resource :dpia, through: :project, shallow: true, parent: false,
-                                     through_association: :dpias,
+                                     through_association: :global_dpias,
                                      class: 'DataPrivacyImpactAssessment'
 
-  # We'll handle this one manually... 
+  # We'll handle this one manually...
   skip_authorize_resource :dpia, only: %i[download]
 
   def index

--- a/app/controllers/data_privacy_impact_assessments_controller.rb
+++ b/app/controllers/data_privacy_impact_assessments_controller.rb
@@ -57,6 +57,7 @@ class DataPrivacyImpactAssessmentsController < ApplicationController
   def resource_params
     params.require(:data_privacy_impact_assessment).permit(
       %i[
+        referent_gid
         ig_toolkit_version
         ig_score
         ig_assessment_status_id

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -1,7 +1,7 @@
 # RESTfully manages `Release`s.
 class ReleasesController < ApplicationController
   load_and_authorize_resource :project
-  load_and_authorize_resource through: :project, shallow: true
+  load_and_authorize_resource through: :project, shallow: true, through_association: :global_releases
 
   def index
     @releases = @releases.paginate(page: params[:page], per_page: 25)

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -40,6 +40,7 @@ class ReleasesController < ApplicationController
   def resource_params
     params.require(:release).permit(
       %i[
+        referent_gid
         invoice_requested_date
         invoice_sent_date
         phe_invoice_number

--- a/app/models/concerns/belongs_to_referent.rb
+++ b/app/models/concerns/belongs_to_referent.rb
@@ -9,7 +9,9 @@ module BelongsToReferent
   included do
     belongs_to :referent, polymorphic: true
 
-    delegate :reference, to: :referent, prefix: true, allow_nil: true
+    # Copy the associated reference to the local model/table (because some groups want to query the
+    # database directly).
+    before_save -> { self.referent_reference = referent&.reference }
   end
 
   def referent_gid

--- a/app/models/concerns/belongs_to_referent.rb
+++ b/app/models/concerns/belongs_to_referent.rb
@@ -1,0 +1,24 @@
+# Shared logic for `Contract`s, `DPIA`s and `Release`s, who need to be associated with a
+# polymorphic parent resource (`Project` or `Amendment`).
+# TODO/FIXME: These resources will also still have a belongs_to association with `Project`. That
+# association could/should be considered a helper association for finding sub-resources within
+# a global scope, irrespective of the true parent resource.
+module BelongsToReferent
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :referent, polymorphic: true
+
+    delegate :reference, to: :referent, prefix: true, allow_nil: true
+  end
+
+  def referent_gid
+    referent&.to_global_id
+  end
+
+  # Using GlobalIDs to set the polymorphic association, since we're not (currently) creating
+  # these resources through the parent via a RESTful routing approach.
+  def referent_gid=(gid)
+    self.referent = GlobalID::Locator.locate(gid)
+  end
+end

--- a/app/models/concerns/has_many_referers.rb
+++ b/app/models/concerns/has_many_referers.rb
@@ -1,0 +1,13 @@
+# Counterpart to `BelongsToReferent`; shared logic for `Project`s and `Amendment`s that may be
+# referenced by `Contract`s, `DPIA`s or `Release`s.
+module HasManyReferers
+  extend ActiveSupport::Concern
+
+  included do
+    with_options as: :referent, dependent: :destroy do
+      has_many :referent_dpias,     class_name: 'DataPrivacyImpactAssessment'
+      has_many :referent_contracts, class_name: 'Contract'
+      has_many :referent_releases,  class_name: 'Release'
+    end
+  end
+end

--- a/app/models/concerns/has_many_referers.rb
+++ b/app/models/concerns/has_many_referers.rb
@@ -5,9 +5,9 @@ module HasManyReferers
 
   included do
     with_options as: :referent, dependent: :destroy do
-      has_many :referent_dpias,     class_name: 'DataPrivacyImpactAssessment'
-      has_many :referent_contracts, class_name: 'Contract'
-      has_many :referent_releases,  class_name: 'Release'
+      has_many :dpias, class_name: 'DataPrivacyImpactAssessment'
+      has_many :contracts
+      has_many :releases
     end
   end
 end

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -1,4 +1,6 @@
 class Contract < ApplicationRecord
+  include BelongsToReferent
+
   has_paper_trail
 
   belongs_to :project

--- a/app/models/data_privacy_impact_assessment.rb
+++ b/app/models/data_privacy_impact_assessment.rb
@@ -1,4 +1,6 @@
 class DataPrivacyImpactAssessment < ApplicationRecord
+  include BelongsToReferent
+
   has_paper_trail
 
   belongs_to :project

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -31,9 +31,9 @@ class Project < ApplicationRecord
   # of accessing _all_ the relevant resources within the scope of a project, irrespective of the
   # true parent resource.
   with_options dependent: :destroy do
-    has_many :dpias, class_name: 'DataPrivacyImpactAssessment'
-    has_many :contracts
-    has_many :releases
+    has_many :global_dpias,     class_name: 'DataPrivacyImpactAssessment'
+    has_many :global_contracts, class_name: 'Contract'
+    has_many :global_releases,  class_name: 'Release'
   end
 
   has_many :project_lawful_bases, dependent: :destroy

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,7 +26,7 @@ class Project < ApplicationRecord
 
   # The following associations are somewhat deprecated (and slightly confusing) now.
   # These resources should have a polymorphic parent (either a project or an amendment;
-  # see `BelongsToReferent` and `HasManyReferers`) and be accessed via `referent_{collection}`.
+  # see `BelongsToReferent` and `HasManyReferers`).
   # That said, these associations (and their inverse counterparts) are kind of useful as a means
   # of accessing _all_ the relevant resources within the scope of a project, irrespective of the
   # true parent resource.

--- a/app/models/project_amendment.rb
+++ b/app/models/project_amendment.rb
@@ -1,6 +1,8 @@
 # An `amendment` represents a formal request to change a `project` in some way, usually late in
 # the lifecycle.
 class ProjectAmendment < ApplicationRecord
+  include HasManyReferers
+
   has_paper_trail
 
   # Quick/dirty categorization for an `amendment`

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,4 +1,6 @@
 class Release < ApplicationRecord
+  include BelongsToReferent
+
   belongs_to :project
   belongs_to :project_state, class_name: 'Workflow::ProjectState'
 

--- a/app/views/contracts/_form.html.erb
+++ b/app/views/contracts/_form.html.erb
@@ -8,6 +8,8 @@
 <%= bootstrap_form_with model: contract, url: url, readonly: readonly, horizontal: true, html: { id: dom_id(contract) } do |form| %>
   <%= form.error_and_warning_alert_boxes %>
 
+  <%= render 'projects/shared/referent_form_fields', project: form.object.project, form: form %>
+
   <%= form.control_group(:contract_version, nil, {}, class: 'col-md-3') do %>
     <%= form.text_field(:contract_version) %>
   <% end %>

--- a/app/views/data_privacy_impact_assessments/_form.html.erb
+++ b/app/views/data_privacy_impact_assessments/_form.html.erb
@@ -8,6 +8,8 @@
 <%= bootstrap_form_with model: dpia, url: url, readonly: readonly, horizontal: true, html: { id: dom_id(dpia) } do |form| %>
   <%= form.error_and_warning_alert_boxes %>
 
+  <%= render 'projects/shared/referent_form_fields', project: form.object.project, form: form %>
+
   <%= form.control_group(:ig_toolkit_version, nil, {}, class: 'col-md-3') do %>
     <%= form.text_field(:ig_toolkit_version) %>
   <% end %>

--- a/app/views/projects/_contracts.html.erb
+++ b/app/views/projects/_contracts.html.erb
@@ -23,7 +23,7 @@
       </tr>
     </thead>
     <tbody>
-      <% project.contracts.accessible_by(current_ability).find_each do |contract| %>
+      <% project.global_contracts.accessible_by(current_ability).find_each do |contract| %>
         <%= content_tag(:tr, id: dom_id(contract)) do %>
           <td><%= contract.referent_reference %></td>
           <td><%= contract.reference %></td>

--- a/app/views/projects/_contracts.html.erb
+++ b/app/views/projects/_contracts.html.erb
@@ -8,6 +8,7 @@
   <table class="table table-condensed" id="contractsTable">
     <thead>
       <tr>
+        <th><%= Contract.human_attribute_name(:referent) %></th>
         <th><%= Contract.human_attribute_name(:reference) %></th>
         <th><%= Contract.human_attribute_name(:contract_version) %></th>
         <th><%= Contract.human_attribute_name(:contract_start_date) %></th>
@@ -24,6 +25,7 @@
     <tbody>
       <% project.contracts.accessible_by(current_ability).find_each do |contract| %>
         <%= content_tag(:tr, id: dom_id(contract)) do %>
+          <td><%= contract.referent_reference %></td>
           <td><%= contract.reference %></td>
           <td><%= contract.contract_version %></td>
           <td><%= contract.contract_start_date&.to_s(:ui) %></td>

--- a/app/views/projects/_dpias.html.erb
+++ b/app/views/projects/_dpias.html.erb
@@ -25,7 +25,7 @@
       </tr>
     </thead>
     <tbody>
-      <% project.dpias.accessible_by(current_ability).find_each do |dpia| %>
+      <% project.global_dpias.accessible_by(current_ability).find_each do |dpia| %>
         <%= content_tag(:tr, id: dom_id(dpia)) do %>
           <td><%= dpia.referent_reference %></td>
           <td><%= dpia.reference %></td>

--- a/app/views/projects/_dpias.html.erb
+++ b/app/views/projects/_dpias.html.erb
@@ -8,6 +8,7 @@
   <table class="table table-condensed">
     <thead>
       <tr>
+        <th><%= DataPrivacyImpactAssessment.human_attribute_name(:referent) %></th>
         <th><%= DataPrivacyImpactAssessment.human_attribute_name(:reference) %></th>
         <th><%= DataPrivacyImpactAssessment.human_attribute_name(:ig_toolkit_version) %></th>
         <th><%= DataPrivacyImpactAssessment.human_attribute_name(:ig_assessment_status_id) %></th>
@@ -26,6 +27,7 @@
     <tbody>
       <% project.dpias.accessible_by(current_ability).find_each do |dpia| %>
         <%= content_tag(:tr, id: dom_id(dpia)) do %>
+          <td><%= dpia.referent_reference %></td>
           <td><%= dpia.reference %></td>
           <td><%= dpia.ig_toolkit_version %></td>
           <td><%= dpia.ig_assessment_status_value %></td>

--- a/app/views/projects/_releases.html.erb
+++ b/app/views/projects/_releases.html.erb
@@ -24,7 +24,7 @@
       </tr>
     </thead>
     <tbody>
-      <% project.releases.accessible_by(current_ability).find_each do |release| %>
+      <% project.global_releases.accessible_by(current_ability).find_each do |release| %>
         <%= content_tag(:tr, id: dom_id(release)) do %>
           <td><%= release.referent_reference %></td>
           <td><%= release.reference %></td>

--- a/app/views/projects/_releases.html.erb
+++ b/app/views/projects/_releases.html.erb
@@ -8,6 +8,7 @@
   <table class="table table-condensed" id="releasesTable">
     <thead>
       <tr>
+        <th><%= Release.human_attribute_name(:referent) %></th>
         <th><%= Release.human_attribute_name(:reference) %></th>
         <th><%= Release.human_attribute_name(:phe_invoice_number) %></th>
         <th><%= Release.human_attribute_name(:po_number) %></th>
@@ -25,6 +26,7 @@
     <tbody>
       <% project.releases.accessible_by(current_ability).find_each do |release| %>
         <%= content_tag(:tr, id: dom_id(release)) do %>
+          <td><%= release.referent_reference %></td>
           <td><%= release.reference %></td>
           <td><%= release.phe_invoice_number %></td>
           <td><%= release.po_number %></td>

--- a/app/views/projects/application/_show_project_tabs.html.erb
+++ b/app/views/projects/application/_show_project_tabs.html.erb
@@ -13,13 +13,13 @@
   </li>
   <%= tab_to ProjectAmendment.model_name.human.pluralize, '#amendments', count: @project.project_amendments.count, data: { toggle: :tab } %>
   <% if can?(:read, DataPrivacyImpactAssessment) %>
-    <%= tab_to DataPrivacyImpactAssessment.model_name.human(count: 2), '#dpias', count: @project.dpias.count, data: { toggle: :tab } %>
+    <%= tab_to DataPrivacyImpactAssessment.model_name.human(count: 2), '#dpias', count: @project.global_dpias.count, data: { toggle: :tab } %>
   <% end %>
   <% if can?(:read, Contract) %>
-    <%= tab_to Contract.model_name.human.pluralize, '#contracts', count: @project.contracts.count, data: { toggle: :tab } %>
+    <%= tab_to Contract.model_name.human.pluralize, '#contracts', count: @project.global_contracts.count, data: { toggle: :tab } %>
   <% end %>
 
-  <%= tab_to(Release.model_name.human.pluralize, '#releases', count: @project.releases.count, data: { toggle: :tab }) %>
+  <%= tab_to(Release.model_name.human.pluralize, '#releases', count: @project.global_releases.count, data: { toggle: :tab }) %>
 
   <li>
     <a href="#uploads" data-toggle='tab'>

--- a/app/views/projects/shared/_referent_form_fields.html.erb
+++ b/app/views/projects/shared/_referent_form_fields.html.erb
@@ -1,0 +1,12 @@
+<%
+  referents = {
+    Project.model_name.human => [[project.reference, project.to_global_id]],
+    ProjectAmendment.model_name.human => project.project_amendments.order(:reference).map do |amendment|
+      [amendment.reference, amendment.to_global_id]
+    end
+  }
+%>
+
+<%= form.control_group(:referent_gid, form.object.class.human_attribute_name(:referent), {}, class: 'col-md-3') do %>
+  <%= form.select :referent_gid, grouped_options_for_select(referents, selected: form.object.referent_gid), include_blank: true, readonly_value: form.object.referent&.reference %>
+<% end %>

--- a/app/views/releases/_form.html.erb
+++ b/app/views/releases/_form.html.erb
@@ -8,6 +8,8 @@
 <%= bootstrap_form_with model: release, url: url, readonly: readonly, horizontal: true, html: { id: dom_id(release) } do |form| %>
   <%= form.error_and_warning_alert_boxes %>
 
+  <%= render 'projects/shared/referent_form_fields', project: form.object.project, form: form %>
+
   <%= form.control_group(:invoice_requested_date, nil, {}, class: 'col-md-3') do %>
     <%= form.datepicker_field(:invoice_requested_date) %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -370,6 +370,7 @@ en:
         assigned_user: Application Manager
       data_privacy_impact_assessment:
         referent: Associated With
+        referent_reference: Associated Reference
         ig_toolkit_version: Year of IG assessment status
         ig_score: IG score
         ig_assessment_status_id: IG assessment status
@@ -378,6 +379,7 @@ en:
         upload: DPIA document
       contract:
         referent: Associated With
+        referent_reference: Associated Reference
         contract_sent_date: Date contract sent to applicant
         contract_returned_date: Date contract returned by applicant
         contract_start_date: Contract start date
@@ -388,6 +390,7 @@ en:
         destruction_form_received_date: Destruction form received
       release:
         referent: Associated With
+        referent_reference: Associated Reference
         phe_invoice_number: PHE Invoice number
         po_number: PO number
         ndg_opt_out_processed_date: National processing data opt outs completed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,6 +369,7 @@ en:
         name: Project Title
         assigned_user: Application Manager
       data_privacy_impact_assessment:
+        referent: Associated With
         ig_toolkit_version: Year of IG assessment status
         ig_score: IG score
         ig_assessment_status_id: IG assessment status
@@ -376,6 +377,7 @@ en:
         dpia_decision_date: DPIA decision date
         upload: DPIA document
       contract:
+        referent: Associated With
         contract_sent_date: Date contract sent to applicant
         contract_returned_date: Date contract returned by applicant
         contract_start_date: Contract start date
@@ -385,6 +387,7 @@ en:
         advisory_letter_date: Advisory letter sent
         destruction_form_received_date: Destruction form received
       release:
+        referent: Associated With
         phe_invoice_number: PHE Invoice number
         po_number: PO number
         ndg_opt_out_processed_date: National processing data opt outs completed

--- a/db/migrate/20210727121915_add_referent_to_contracts.rb
+++ b/db/migrate/20210727121915_add_referent_to_contracts.rb
@@ -1,0 +1,5 @@
+class AddReferentToContracts < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :contracts, :referent, polymorphic: true, index: true
+  end
+end

--- a/db/migrate/20210727121924_add_referent_to_dpias.rb
+++ b/db/migrate/20210727121924_add_referent_to_dpias.rb
@@ -1,0 +1,5 @@
+class AddReferentToDpias < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :data_privacy_impact_assessments, :referent, polymorphic: true, index: { name: :index_dpias_on_referent_type_and_referent_id }
+  end
+end

--- a/db/migrate/20210727121941_add_referent_to_releases.rb
+++ b/db/migrate/20210727121941_add_referent_to_releases.rb
@@ -1,0 +1,5 @@
+class AddReferentToReleases < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :releases, :referent, polymorphic: true, index: true
+  end
+end

--- a/db/migrate/20210728114812_populate_referent_on_contracts.rb
+++ b/db/migrate/20210728114812_populate_referent_on_contracts.rb
@@ -1,0 +1,12 @@
+class PopulateReferentOnContracts < ActiveRecord::Migration[6.0]
+  class Contract < ApplicationRecord; end
+
+  def up
+    Contract.find_each do |contract|
+      contract.update!(referent_type: 'Project', referent_id: contract.project_id)
+    end
+  end
+
+  # no-op
+  def down; end
+end

--- a/db/migrate/20210728114817_populate_referent_on_dpias.rb
+++ b/db/migrate/20210728114817_populate_referent_on_dpias.rb
@@ -1,0 +1,14 @@
+class PopulateReferentOnDpias < ActiveRecord::Migration[6.0]
+  class DPIA < ApplicationRecord
+    self.table_name = 'data_privacy_impact_assessments'
+  end
+
+  def up
+    DPIA.find_each do |dpia|
+      dpia.update!(referent_type: 'Project', referent_id: dpia.project_id)
+    end
+  end
+
+  # no-op
+  def down; end
+end

--- a/db/migrate/20210728114821_populate_referent_on_releases.rb
+++ b/db/migrate/20210728114821_populate_referent_on_releases.rb
@@ -1,0 +1,12 @@
+class PopulateReferentOnReleases < ActiveRecord::Migration[6.0]
+  class Release < ApplicationRecord; end
+
+  def up
+    Release.find_each do |release|
+      release.update!(referent_type: 'Project', referent_id: release.project_id)
+    end
+  end
+
+  # no-op
+  def down; end
+end

--- a/db/migrate/20210728115617_alter_referent_nullability_on_contracts.rb
+++ b/db/migrate/20210728115617_alter_referent_nullability_on_contracts.rb
@@ -1,0 +1,6 @@
+class AlterReferentNullabilityOnContracts < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :contracts, :referent_type, false
+    change_column_null :contracts, :referent_id,   false
+  end
+end

--- a/db/migrate/20210728115621_alter_referent_nullability_on_dpias.rb
+++ b/db/migrate/20210728115621_alter_referent_nullability_on_dpias.rb
@@ -1,0 +1,6 @@
+class AlterReferentNullabilityOnDpias < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :data_privacy_impact_assessments, :referent_type, false
+    change_column_null :data_privacy_impact_assessments, :referent_id,   false
+  end
+end

--- a/db/migrate/20210728115625_alter_referent_nullability_on_releases.rb
+++ b/db/migrate/20210728115625_alter_referent_nullability_on_releases.rb
@@ -1,0 +1,6 @@
+class AlterReferentNullabilityOnReleases < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :releases, :referent_type, false
+    change_column_null :releases, :referent_id,   false
+  end
+end

--- a/db/migrate/20210728140133_add_referent_reference_to_contracts.rb
+++ b/db/migrate/20210728140133_add_referent_reference_to_contracts.rb
@@ -1,0 +1,5 @@
+class AddReferentReferenceToContracts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :contracts, :referent_reference, :string
+  end
+end

--- a/db/migrate/20210728140140_add_referent_reference_to_dpias.rb
+++ b/db/migrate/20210728140140_add_referent_reference_to_dpias.rb
@@ -1,0 +1,5 @@
+class AddReferentReferenceToDpias < ActiveRecord::Migration[6.0]
+  def change
+    add_column :data_privacy_impact_assessments, :referent_reference, :string
+  end
+end

--- a/db/migrate/20210728140147_add_referent_reference_to_releases.rb
+++ b/db/migrate/20210728140147_add_referent_reference_to_releases.rb
@@ -1,0 +1,5 @@
+class AddReferentReferenceToReleases < ActiveRecord::Migration[6.0]
+  def change
+    add_column :releases, :referent_reference, :string
+  end
+end

--- a/db/migrate/20210728140306_populate_referent_reference_on_contracts.rb
+++ b/db/migrate/20210728140306_populate_referent_reference_on_contracts.rb
@@ -1,0 +1,16 @@
+class PopulateReferentReferenceOnContracts < ActiveRecord::Migration[6.0]
+  class Contract < ApplicationRecord
+    belongs_to :referent, polymorphic: true, optional: true
+  end
+
+  def up
+    Contract.find_each do |contract|
+      next unless referent ||= contract.referent
+
+      contract.update!(referent_reference: referent.reference)
+    end
+  end
+
+  # no-op
+  def down; end
+end

--- a/db/migrate/20210728140310_populate_referent_reference_on_dpias.rb
+++ b/db/migrate/20210728140310_populate_referent_reference_on_dpias.rb
@@ -1,0 +1,18 @@
+class PopulateReferentReferenceOnDpias < ActiveRecord::Migration[6.0]
+  class DPIA < ApplicationRecord
+    self.table_name = 'data_privacy_impact_assessments'
+
+    belongs_to :referent, polymorphic: true, optional: true
+  end
+
+  def up
+    DPIA.find_each do |dpia|
+      next unless referent ||= dpia.referent
+
+      dpia.update!(referent_reference: referent.reference)
+    end
+  end
+
+  # no-op
+  def down; end
+end

--- a/db/migrate/20210728140313_populate_referent_reference_on_releases.rb
+++ b/db/migrate/20210728140313_populate_referent_reference_on_releases.rb
@@ -1,0 +1,16 @@
+class PopulateReferentReferenceOnReleases < ActiveRecord::Migration[6.0]
+  class Release < ApplicationRecord
+    belongs_to :referent, polymorphic: true, optional: true
+  end
+
+  def up
+    Release.find_each do |release|
+      next unless referent ||= release.referent
+
+      release.update!(referent_reference: referent.reference)
+    end
+  end
+
+  # no-op
+  def down; end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -634,7 +634,8 @@ CREATE TABLE public.contracts (
     destruction_form_received_date timestamp without time zone,
     reference character varying,
     referent_type character varying NOT NULL,
-    referent_id bigint NOT NULL
+    referent_id bigint NOT NULL,
+    referent_reference character varying
 );
 
 
@@ -834,7 +835,8 @@ CREATE TABLE public.data_privacy_impact_assessments (
     updated_at timestamp(6) without time zone NOT NULL,
     reference character varying,
     referent_type character varying NOT NULL,
-    referent_id bigint NOT NULL
+    referent_id bigint NOT NULL,
+    referent_reference character varying
 );
 
 
@@ -3606,7 +3608,8 @@ CREATE TABLE public.releases (
     updated_at timestamp(6) without time zone NOT NULL,
     reference character varying,
     referent_type character varying NOT NULL,
-    referent_id bigint NOT NULL
+    referent_id bigint NOT NULL,
+    referent_reference character varying
 );
 
 
@@ -8312,6 +8315,12 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210728114821'),
 ('20210728115617'),
 ('20210728115621'),
-('20210728115625');
+('20210728115625'),
+('20210728140133'),
+('20210728140140'),
+('20210728140147'),
+('20210728140306'),
+('20210728140310'),
+('20210728140313');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -165,8 +165,8 @@ ALTER SEQUENCE public.amendment_types_id_seq OWNED BY public.amendment_types.id;
 CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
 );
 
 
@@ -276,6 +276,19 @@ CREATE TABLE public.cas_application_fields (
     id bigint NOT NULL,
     project_id bigint,
     status character varying,
+    firstname character varying,
+    surname character varying,
+    jobtitle character varying,
+    phe_email character varying,
+    work_number character varying,
+    organisation character varying,
+    line_manager_name character varying,
+    line_manager_email character varying,
+    line_manager_number character varying,
+    employee_type character varying,
+    contract_startdate date,
+    contract_enddate date,
+    username character varying,
     address text,
     n3_ip_address text,
     reason_justification text,
@@ -284,20 +297,7 @@ CREATE TABLE public.cas_application_fields (
     extra_datasets_rationale character varying,
     declaration character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    organisation character varying,
-    username character varying,
-    contract_enddate date,
-    contract_startdate date,
-    employee_type character varying,
-    line_manager_number character varying,
-    line_manager_email character varying,
-    line_manager_name character varying,
-    work_number character varying,
-    phe_email character varying,
-    jobtitle character varying,
-    surname character varying,
-    firstname character varying
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -632,7 +632,9 @@ CREATE TABLE public.contracts (
     contract_executed_date timestamp without time zone,
     advisory_letter_date timestamp without time zone,
     destruction_form_received_date timestamp without time zone,
-    reference character varying
+    reference character varying,
+    referent_type character varying NOT NULL,
+    referent_id bigint NOT NULL
 );
 
 
@@ -830,7 +832,9 @@ CREATE TABLE public.data_privacy_impact_assessments (
     dpia_decision_date timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    reference character varying
+    reference character varying,
+    referent_type character varying NOT NULL,
+    referent_id bigint NOT NULL
 );
 
 
@@ -2180,13 +2184,13 @@ CREATE TABLE public.molecular_data (
     providercode text,
     practitionercode text,
     patienttype text,
+    moleculartestingtype integer,
     requesteddate date,
     collecteddate date,
     receiveddate date,
     authoriseddate date,
     indicationcategory integer,
     clinicalindication text,
-    moleculartestingtype integer,
     organisationcode_testresult text,
     servicereportidentifier text,
     specimentype integer,
@@ -2760,12 +2764,12 @@ CREATE TABLE public.project_attachments (
     comments character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
+    attachment_contents bytea,
+    digest character varying,
     attachment_file_name character varying,
     attachment_content_type character varying,
     attachment_file_size integer,
     attachment_updated_at timestamp without time zone,
-    attachment_contents bytea,
-    digest character varying,
     workflow_project_state_id bigint,
     attachable_type character varying,
     attachable_id bigint
@@ -3600,7 +3604,9 @@ CREATE TABLE public.releases (
     release_date timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    reference character varying
+    reference character varying,
+    referent_type character varying NOT NULL,
+    referent_id bigint NOT NULL
 );
 
 
@@ -6253,6 +6259,13 @@ CREATE INDEX index_contracts_on_project_state_id ON public.contracts USING btree
 
 
 --
+-- Name: index_contracts_on_referent_type_and_referent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_contracts_on_referent_type_and_referent_id ON public.contracts USING btree (referent_type, referent_id);
+
+
+--
 -- Name: index_cost_recoveries_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6313,6 +6326,13 @@ CREATE INDEX index_death_data_on_ppatient_id ON public.death_data USING btree (p
 --
 
 CREATE INDEX index_dpias_on_ig_assessment_status_id ON public.data_privacy_impact_assessments USING btree (ig_assessment_status_id);
+
+
+--
+-- Name: index_dpias_on_referent_type_and_referent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_dpias_on_referent_type_and_referent_id ON public.data_privacy_impact_assessments USING btree (referent_type, referent_id);
 
 
 --
@@ -6768,6 +6788,13 @@ CREATE INDEX index_releases_on_project_id ON public.releases USING btree (projec
 --
 
 CREATE INDEX index_releases_on_project_state_id ON public.releases USING btree (project_state_id);
+
+
+--
+-- Name: index_releases_on_referent_type_and_referent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_releases_on_referent_type_and_referent_id ON public.releases USING btree (referent_type, referent_id);
 
 
 --
@@ -8276,6 +8303,15 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210615101111'),
 ('20210615104916'),
 ('20210617140742'),
-('20210628103955');
+('20210628103955'),
+('20210727121915'),
+('20210727121924'),
+('20210727121941'),
+('20210728114812'),
+('20210728114817'),
+('20210728114821'),
+('20210728115617'),
+('20210728115621'),
+('20210728115625');
 
 

--- a/test/create_records_helper.rb
+++ b/test/create_records_helper.rb
@@ -190,6 +190,7 @@ module CreateRecordsHelper
     )
 
     attributes.reverse_merge!(
+      referent: project,
       ig_toolkit_version: '2019/20',
       ig_score: 100,
       ig_assessment_status: lookups_ig_assessment_statuses(:standards_met),
@@ -210,6 +211,7 @@ module CreateRecordsHelper
     )
 
     attributes.reverse_merge!(
+      referent:               project,
       contract_start_date:    Time.zone.today + 1.week,
       contract_end_date:      Time.zone.today + 1.year,
       contract_sent_date:     Time.zone.today - 2.weeks,
@@ -224,6 +226,7 @@ module CreateRecordsHelper
 
   def create_release(project, **attributes)
     attributes.reverse_merge!(
+      referent:               project,
       invoice_requested_date: 1.week.ago,
       invoice_sent_date:      1.day.ago,
       phe_invoice_number:     'PHE-1234',

--- a/test/create_records_helper.rb
+++ b/test/create_records_helper.rb
@@ -198,7 +198,7 @@ module CreateRecordsHelper
       upload: upload
     )
 
-    project.dpias.create!(attributes)
+    project.global_dpias.create!(attributes)
   end
 
   def create_contract(project, **attributes)
@@ -221,7 +221,7 @@ module CreateRecordsHelper
       upload:                 upload
     )
 
-    project.contracts.create!(attributes)
+    project.global_contracts.create!(attributes)
   end
 
   def create_release(project, **attributes)
@@ -239,6 +239,6 @@ module CreateRecordsHelper
       cost_recovery_applied:  'N'
     )
 
-    project.releases.create!(attributes)
+    project.global_releases.create!(attributes)
   end
 end

--- a/test/integration/contracts_test.rb
+++ b/test/integration/contracts_test.rb
@@ -41,8 +41,8 @@ class ContractsTest < ActionDispatch::IntegrationTest
     fill_in 'contract[contract_executed_date]', with: '01/04/2020'
     attach_file('contract[upload]', file_fixture('contract.txt'))
 
-    assert_difference -> { project.contracts.count } do
-      assert_difference -> { project.referent_contracts.count } do
+    assert_difference -> { project.global_contracts.count } do
+      assert_difference -> { project.contracts.count } do
         click_button('Create Contract')
 
         assert_equal project_path(project), current_path
@@ -81,8 +81,8 @@ class ContractsTest < ActionDispatch::IntegrationTest
     visit project_path(project)
     click_on('Contracts')
 
-    assert_difference -> { project.contracts.count }, -1 do
-      assert_difference -> { project.referent_contracts.count }, -1 do
+    assert_difference -> { project.global_contracts.count }, -1 do
+      assert_difference -> { project.contracts.count }, -1 do
         accept_prompt do
           click_link(href: contract_path(contract), title: 'Delete')
         end

--- a/test/integration/contracts_test.rb
+++ b/test/integration/contracts_test.rb
@@ -32,6 +32,7 @@ class ContractsTest < ActionDispatch::IntegrationTest
 
     click_link('New')
 
+    select  project.reference,                  from: 'Associated With'
     fill_in 'contract[contract_version]',       with: 'test-0.0.1'
     fill_in 'contract[contract_start_date]',    with: '08/04/2020'
     fill_in 'contract[contract_end_date]',      with: '01/04/2021'
@@ -41,11 +42,13 @@ class ContractsTest < ActionDispatch::IntegrationTest
     attach_file('contract[upload]', file_fixture('contract.txt'))
 
     assert_difference -> { project.contracts.count } do
-      click_button('Create Contract')
+      assert_difference -> { project.referent_contracts.count } do
+        click_button('Create Contract')
 
-      assert_equal project_path(project), current_path
-      assert has_text?('Contract created successfully')
-      assert has_selector?('#contractsTable', visible: true)
+        assert_equal project_path(project), current_path
+        assert has_text?('Contract created successfully')
+        assert has_selector?('#contractsTable', visible: true)
+      end
     end
   end
 
@@ -79,12 +82,14 @@ class ContractsTest < ActionDispatch::IntegrationTest
     click_on('Contracts')
 
     assert_difference -> { project.contracts.count }, -1 do
-      accept_prompt do
-        click_link(href: contract_path(contract), title: 'Delete')
-      end
+      assert_difference -> { project.referent_contracts.count }, -1 do
+        accept_prompt do
+          click_link(href: contract_path(contract), title: 'Delete')
+        end
 
-      assert_equal project_path(project), current_path
-      assert has_selector?('#contractsTable', visible: true)
+        assert_equal project_path(project), current_path
+        assert has_selector?('#contractsTable', visible: true)
+      end
     end
 
     assert has_text?('Contract destroyed successfully')

--- a/test/integration/data_privacy_impact_assessments_test.rb
+++ b/test/integration/data_privacy_impact_assessments_test.rb
@@ -40,18 +40,21 @@ class DataPrivacyImpactAssessmentsTest < ActionDispatch::IntegrationTest
 
     click_link('New')
 
-    select 'Standards met', from: 'data_privacy_impact_assessment[ig_assessment_status_id]'
+    select project.reference,  from: 'Associated With'
+    select 'Standards met',    from: 'data_privacy_impact_assessment[ig_assessment_status_id]'
     fill_in 'data_privacy_impact_assessment[ig_toolkit_version]',  with: '2019/20'
     fill_in 'data_privacy_impact_assessment[review_meeting_date]', with: '07/04/2020'
     fill_in 'data_privacy_impact_assessment[dpia_decision_date]',  with: '14/04/2020'
     attach_file('data_privacy_impact_assessment[upload]', file_fixture('dpia.txt'))
 
     assert_difference -> { project.dpias.count } do
-      click_button('Create DPIA')
+      assert_difference -> { project.referent_dpias.count } do
+        click_button('Create DPIA')
 
-      assert_equal project_path(project), current_path
-      assert has_text?('DPIA created successfully')
-      # assert has_selector?('#projectAmendments', visible: true)
+        assert_equal project_path(project), current_path
+        assert has_text?('DPIA created successfully')
+        # assert has_selector?('#projectAmendments', visible: true)
+      end
     end
   end
 
@@ -91,11 +94,13 @@ class DataPrivacyImpactAssessmentsTest < ActionDispatch::IntegrationTest
     click_on('DPIAs')
 
     assert_difference -> { project.dpias.count }, -1 do
-      accept_prompt do
-        click_link(href: data_privacy_impact_assessment_path(dpia), title: 'Delete')
-      end
+      assert_difference -> { project.referent_dpias.count }, -1 do
+        accept_prompt do
+          click_link(href: data_privacy_impact_assessment_path(dpia), title: 'Delete')
+        end
 
-      assert_equal project_path(project), current_path
+        assert_equal project_path(project), current_path
+      end
     end
 
     assert has_text?('DPIA destroyed successfully')

--- a/test/integration/data_privacy_impact_assessments_test.rb
+++ b/test/integration/data_privacy_impact_assessments_test.rb
@@ -47,8 +47,8 @@ class DataPrivacyImpactAssessmentsTest < ActionDispatch::IntegrationTest
     fill_in 'data_privacy_impact_assessment[dpia_decision_date]',  with: '14/04/2020'
     attach_file('data_privacy_impact_assessment[upload]', file_fixture('dpia.txt'))
 
-    assert_difference -> { project.dpias.count } do
-      assert_difference -> { project.referent_dpias.count } do
+    assert_difference -> { project.global_dpias.count } do
+      assert_difference -> { project.dpias.count } do
         click_button('Create DPIA')
 
         assert_equal project_path(project), current_path
@@ -93,8 +93,8 @@ class DataPrivacyImpactAssessmentsTest < ActionDispatch::IntegrationTest
     visit project_path(project)
     click_on('DPIAs')
 
-    assert_difference -> { project.dpias.count }, -1 do
-      assert_difference -> { project.referent_dpias.count }, -1 do
+    assert_difference -> { project.global_dpias.count }, -1 do
+      assert_difference -> { project.dpias.count }, -1 do
         accept_prompt do
           click_link(href: data_privacy_impact_assessment_path(dpia), title: 'Delete')
         end

--- a/test/integration/releases_test.rb
+++ b/test/integration/releases_test.rb
@@ -32,6 +32,7 @@ class ReleasesTest < ActionDispatch::IntegrationTest
 
     click_link('New')
 
+    select  project.reference,                     from: 'Associated With'
     fill_in 'release[invoice_requested_date]',     with: '15/04/2020'
     fill_in 'release[invoice_sent_date]',          with: '15/04/2020'
     fill_in 'release[phe_invoice_number]',         with: 'PHE-1234'
@@ -47,11 +48,13 @@ class ReleasesTest < ActionDispatch::IntegrationTest
     fill_in 'release[release_date]',               with: '15/04/2020'
 
     assert_difference -> { project.releases.count } do
-      click_button('Create Release')
+      assert_difference -> { project.referent_releases.count } do
+        click_button('Create Release')
 
-      assert_equal project_path(project), current_path
-      assert has_text?('Release created successfully')
-      assert has_selector?('#releasesTable', visible: true)
+        assert_equal project_path(project), current_path
+        assert has_text?('Release created successfully')
+        assert has_selector?('#releasesTable', visible: true)
+      end
     end
   end
 
@@ -85,12 +88,14 @@ class ReleasesTest < ActionDispatch::IntegrationTest
     click_on('Releases')
 
     assert_difference -> { project.releases.count }, -1 do
-      accept_prompt do
-        click_link(href: release_path(release), title: 'Delete')
-      end
+      assert_difference -> { project.referent_releases.count }, -1 do
+        accept_prompt do
+          click_link(href: release_path(release), title: 'Delete')
+        end
 
-      assert_equal project_path(project), current_path
-      assert has_selector?('#releasesTable', visible: true)
+        assert_equal project_path(project), current_path
+        assert has_selector?('#releasesTable', visible: true)
+      end
     end
 
     assert has_text?('Release destroyed successfully')

--- a/test/integration/releases_test.rb
+++ b/test/integration/releases_test.rb
@@ -47,8 +47,8 @@ class ReleasesTest < ActionDispatch::IntegrationTest
     fill_in 'release[individual_to_release]',      with: 'Yogi Bear'
     fill_in 'release[release_date]',               with: '15/04/2020'
 
-    assert_difference -> { project.releases.count } do
-      assert_difference -> { project.referent_releases.count } do
+    assert_difference -> { project.global_releases.count } do
+      assert_difference -> { project.releases.count } do
         click_button('Create Release')
 
         assert_equal project_path(project), current_path
@@ -87,8 +87,8 @@ class ReleasesTest < ActionDispatch::IntegrationTest
     visit project_path(project)
     click_on('Releases')
 
-    assert_difference -> { project.releases.count }, -1 do
-      assert_difference -> { project.referent_releases.count }, -1 do
+    assert_difference -> { project.global_releases.count }, -1 do
+      assert_difference -> { project.releases.count }, -1 do
         accept_prompt do
           click_link(href: release_path(release), title: 'Delete')
         end

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -791,7 +791,7 @@ class AbilityTest < ActiveSupport::TestCase
     project.grants.build(user: project_member, roleable: ProjectRole.fetch(:read_only))
     project.save!
 
-    release = project.releases.build
+    release = project.global_releases.build
 
     refute project_member.can?      :read, release
     refute project_owner.can?       :read, release

--- a/test/models/concerns/belongs_to_lookup_test.rb
+++ b/test/models/concerns/belongs_to_lookup_test.rb
@@ -3,7 +3,10 @@ require 'test_helper'
 # Tests the BelongsToLookup concern
 class BelongsToLookupTest < ActiveSupport::TestCase
   def setup
-    @release = Release.new(project: projects(:dummy_project))
+    @release = Release.new(
+      project:  projects(:dummy_project),
+      referent: projects(:dummy_project)
+    )
   end
 
   test 'belongs_to_lookup should allow valid value' do

--- a/test/models/concerns/belongs_to_referent_test.rb
+++ b/test/models/concerns/belongs_to_referent_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+# Tests behaviour of the `BelongsToReferent` concern.
+class BelongsToReferentTest < ActiveSupport::TestCase
+  def setup
+    @resource = create_contract(projects(:dummy_project))
+  end
+
+  test 'should belong_to a referent' do
+    assert @resource.class.reflect_on_association(:referent)
+    assert_kind_of ApplicationRecord, @resource.referent
+  end
+
+  test 'should be invalid without an associated referent' do
+    @resource.referent = nil
+
+    refute @resource.valid?
+    assert_includes @resource.errors.details[:referent], error: :blank
+  end
+
+  test 'should return the GlobalID for the associated resource' do
+    gid = @resource.referent.to_global_id
+
+    assert_equal gid, @resource.referent_gid
+  end
+
+  test 'should allow related resource to be assigned via GlobalID' do
+    referent = @resource.referent
+    @resource.referent = nil
+
+    @resource.referent_gid = referent.to_global_id
+
+    assert_equal referent, @resource.referent
+  end
+
+  test 'should delegate :reference to related resource' do
+    referent = @resource.referent
+
+    referent.expects(:reference)
+    @resource.referent_reference
+  end
+end

--- a/test/models/concerns/belongs_to_referent_test.rb
+++ b/test/models/concerns/belongs_to_referent_test.rb
@@ -33,10 +33,12 @@ class BelongsToReferentTest < ActiveSupport::TestCase
     assert_equal referent, @resource.referent
   end
 
-  test 'should delegate :reference to related resource' do
+  test 'should save related resource reference locally on save' do
     referent = @resource.referent
+    referent.class.any_instance.stubs(reference: 'project.ref.123')
 
-    referent.expects(:reference)
-    @resource.referent_reference
+    assert_changes -> { @resource.reload.referent_reference }, from: nil, to: 'project.ref.123' do
+      @resource.save!
+    end
   end
 end

--- a/test/models/concerns/has_many_referrers_test.rb
+++ b/test/models/concerns/has_many_referrers_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+# Tests behaviour of the `HasManyReferers` concern.
+class HasManyReferersTest < ActiveSupport::TestCase
+  def setup
+    @resource = projects(:dummy_project)
+  end
+
+  test 'should have many referrers' do
+    assert @resource.class.reflect_on_association(:referent_contracts)
+    assert @resource.class.reflect_on_association(:referent_releases)
+    assert @resource.class.reflect_on_association(:referent_dpias)
+
+    assert_instance_of ::Contract, @resource.referent_contracts.build
+    assert_instance_of ::Release,  @resource.referent_releases.build
+    assert_instance_of ::DataPrivacyImpactAssessment, @resource.referent_dpias.build
+  end
+end

--- a/test/models/concerns/has_many_referrers_test.rb
+++ b/test/models/concerns/has_many_referrers_test.rb
@@ -7,12 +7,12 @@ class HasManyReferersTest < ActiveSupport::TestCase
   end
 
   test 'should have many referrers' do
-    assert @resource.class.reflect_on_association(:referent_contracts)
-    assert @resource.class.reflect_on_association(:referent_releases)
-    assert @resource.class.reflect_on_association(:referent_dpias)
+    assert @resource.class.reflect_on_association(:contracts)
+    assert @resource.class.reflect_on_association(:releases)
+    assert @resource.class.reflect_on_association(:dpias)
 
-    assert_instance_of ::Contract, @resource.referent_contracts.build
-    assert_instance_of ::Release,  @resource.referent_releases.build
-    assert_instance_of ::DataPrivacyImpactAssessment, @resource.referent_dpias.build
+    assert_instance_of ::Contract, @resource.contracts.build
+    assert_instance_of ::Release,  @resource.releases.build
+    assert_instance_of ::DataPrivacyImpactAssessment, @resource.dpias.build
   end
 end

--- a/test/models/concerns/workflow/model_test.rb
+++ b/test/models/concerns/workflow/model_test.rb
@@ -288,7 +288,7 @@ module Workflow
       assert project.transition_to(workflow_states(:submitted))
       assert project.transition_to(workflow_states(:dpia_start))
 
-      project.dpias.destroy_all
+      project.global_dpias.destroy_all
       refute project.transition_to(workflow_states(:dpia_review))
       assert_includes project.errors.details[:base], error: :no_attached_dpia
 
@@ -305,7 +305,7 @@ module Workflow
       assert project.transition_to(workflow_states(:dpia_review))
       assert project.transition_to(workflow_states(:dpia_moderation))
 
-      project.contracts.destroy_all
+      project.global_contracts.destroy_all
       refute project.transition_to(workflow_states(:contract_draft))
       assert_includes project.errors.details[:base], error: :no_attached_contract
 

--- a/test/models/contract_test.rb
+++ b/test/models/contract_test.rb
@@ -13,10 +13,10 @@ class ContractTest < ActiveSupport::TestCase
 
   test 'should belong to a project' do
     project  = projects(:one)
-    contract = project.contracts.build
+    contract = project.global_contracts.build
 
     assert_equal project, contract.project
-    assert_includes project.contracts, contract
+    assert_includes project.global_contracts, contract
   end
 
   test 'should be invalid without a project' do
@@ -51,7 +51,7 @@ class ContractTest < ActiveSupport::TestCase
 
   test 'should be auditable' do
     project  = projects(:one)
-    contract = project.contracts.build
+    contract = project.global_contracts.build
 
     with_versioning do
       assert_auditable contract
@@ -86,7 +86,7 @@ class ContractTest < ActiveSupport::TestCase
   private
 
   def build_contract(project, **attributes)
-    project.contracts.build(referent: project, **attributes) do |contract|
+    project.global_contracts.build(referent: project, **attributes) do |contract|
       yield(contract) if block_given?
     end
   end

--- a/test/models/data_privacy_impact_assessment_test.rb
+++ b/test/models/data_privacy_impact_assessment_test.rb
@@ -28,6 +28,10 @@ class DataPrivacyImpactAssessmentTest < ActiveSupport::TestCase
     assert_equal project.current_project_state, dpia.project_state
   end
 
+  test 'should include BelongsToReferent' do
+    assert_includes DataPrivacyImpactAssessment.included_modules, BelongsToReferent
+  end
+
   test 'should be invalid without an associated project_state' do
     dpia = DataPrivacyImpactAssessment.new
     dpia.valid?

--- a/test/models/data_privacy_impact_assessment_test.rb
+++ b/test/models/data_privacy_impact_assessment_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 class DataPrivacyImpactAssessmentTest < ActiveSupport::TestCase
   test 'should belong to a project' do
     project = projects(:one)
-    dpia    = project.dpias.build
+    dpia    = project.global_dpias.build
 
     assert_equal project, dpia.project
-    assert_includes project.dpias, dpia
+    assert_includes project.global_dpias, dpia
   end
 
   test 'should be invalid without a project' do
@@ -41,7 +41,7 @@ class DataPrivacyImpactAssessmentTest < ActiveSupport::TestCase
 
   test 'should not permit ig_score outside permissible range' do
     project = projects(:one)
-    dpia    = project.dpias.build
+    dpia    = project.global_dpias.build
 
     dpia.ig_score = -1
     dpia.valid?
@@ -62,7 +62,7 @@ class DataPrivacyImpactAssessmentTest < ActiveSupport::TestCase
 
   test 'should not permit fractional ig_score values' do
     project = projects(:one)
-    dpia    = project.dpias.build(ig_score: 50.0)
+    dpia    = project.global_dpias.build(ig_score: 50.0)
 
     dpia.valid?
     assert_includes dpia.errors.details[:ig_score], error: :not_an_integer, value: 50.0
@@ -70,7 +70,7 @@ class DataPrivacyImpactAssessmentTest < ActiveSupport::TestCase
 
   test 'should be auditable' do
     project = projects(:one)
-    dpia    = project.dpias.build
+    dpia    = project.global_dpias.build
 
     with_versioning do
       assert_auditable dpia

--- a/test/models/project_amendment_test.rb
+++ b/test/models/project_amendment_test.rb
@@ -21,6 +21,10 @@ class ProjectAmendmentTest < ActiveSupport::TestCase
     refute_includes amendment.errors.details[:project], error: :blank
   end
 
+  test 'should include HasManyReferers' do
+    assert_includes ProjectAmendment.included_modules, HasManyReferers
+  end
+
   test 'should be associated with a project state' do
     project   = projects(:one)
     amendment = create_amendment(project)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -3,6 +3,10 @@ require 'test_helper'
 class ProjectTest < ActiveSupport::TestCase
   include ActionMailer::TestHelper
 
+  test 'should include HasManyReferers' do
+    assert_includes ProjectAmendment.included_modules, HasManyReferers
+  end
+
   test 'should remove project data items when data source changed' do
     project = build_and_validate_project
     dataset = Dataset.find_by(name: 'Births Gold Standard')

--- a/test/models/release_test.rb
+++ b/test/models/release_test.rb
@@ -12,10 +12,10 @@ class ReleaseTest < ActiveSupport::TestCase
 
   test 'should belong to a project' do
     project = projects(:one)
-    release = project.releases.build
+    release = project.global_releases.build
 
     assert_equal project, release.project
-    assert_includes project.releases, release
+    assert_includes project.global_releases, release
   end
 
   test 'should be invalid without a project' do
@@ -36,7 +36,7 @@ class ReleaseTest < ActiveSupport::TestCase
 
   test 'should be associated with a project state' do
     project = projects(:one)
-    release = project.releases.build
+    release = project.global_releases.build
 
     release.valid?
 
@@ -52,7 +52,7 @@ class ReleaseTest < ActiveSupport::TestCase
 
   test 'should be auditable' do
     project = projects(:one)
-    release = project.releases.build
+    release = project.global_releases.build
 
     with_versioning do
       assert_auditable release
@@ -61,7 +61,7 @@ class ReleaseTest < ActiveSupport::TestCase
 
   test 'should validate numericality of actual_cost' do
     project = projects(:one)
-    release = project.releases.build
+    release = project.global_releases.build
 
     release.actual_cost = 'not a number'
     release.valid?
@@ -106,7 +106,7 @@ class ReleaseTest < ActiveSupport::TestCase
   private
 
   def build_release(project, **attributes)
-    project.releases.build(referent: project, **attributes) do |release|
+    project.global_releases.build(referent: project, **attributes) do |release|
       yield(release) if block_given?
     end
   end


### PR DESCRIPTION
This PR adds the requested ability to associate `Contract`, `DPIA`, and `Release` resources to be related to either a `Project` or an `Amendment`.

Implementing this via polymorphic association because it feels like the right thing to do in terms of "the Rails way". 
It does leave a slightly confusing set of associations in the wake, but I've added some comments to the code to hopefully explain things for the poor soul who comes next. 
Generally, the gist is that polymorphic association is used to determine the parent record, while the previous project association remains as a means of accessing all the records of a given type, in a wider scope.

And because there's some expectation of being able to query the database directly, I'm denormalising the associated references out to the child records (ultimately, that's what I think the requestors are expecting to see anyway). 
