### PR TITLE
Enable emails on contract approved/rejected [#19483]

### DIFF
--- a/app/mailers/concerns/workflow/mail.rb
+++ b/app/mailers/concerns/workflow/mail.rb
@@ -46,10 +46,11 @@ module Workflow
       end
     end
     alias transitioned_to_rejected transitioned
+    alias application_transitioned_to_contract_completed transitioned
+    alias application_transitioned_to_contract_rejected  transitioned
 
     def application_transitioned_to_rejected
       @interpolations = default_interpolations.merge!(
-        current_user:   @current_user.full_name,
         closure_reason: @project.closure_reason.value
       )
 
@@ -75,9 +76,10 @@ module Workflow
 
     def default_interpolations
       {
-        type:  @project.project_type_name,
-        state: @project.current_state_name,
-        title: @project.name
+        current_user: @current_user.full_name,
+        type:         @project.project_type_name,
+        state:        @project.current_state_name,
+        title:        @project.name
       }
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -455,3 +455,13 @@ en-odr:
         A project you are managing has been closed by %{current_user}.
 
         Closure reason: %{closure_reason}
+    application_transitioned_to_contract_completed:
+      body_html: >
+        <p>A project you are managing has had the contract approved by %{current_user}.</p>
+      body: |
+        A project you are managing has had the contract approved by %{current_user}.
+    application_transitioned_to_contract_rejected:
+      body_html: >
+        <p>A project you are managing has had the contract rejected by %{current_user}.</p>
+      body: |
+        A project you are managing has had the contract rejected by %{current_user}.


### PR DESCRIPTION
As per title; enables emails to be sent to project users (inc. assigned application manager) when a contract is either approved or rejected.
