### PR TITLE
Add error message if no first contact date added when uploading a pdf form [#27162]

### DIFF
--- a/app/facades/pdf_application_facade.rb
+++ b/app/facades/pdf_application_facade.rb
@@ -208,7 +208,7 @@ class PdfApplicationFacade
   end
 
   def level_of_identifiability=(value)
-    classifications.replace([fetch_classification(value)])
+    classifications.replace(Array.wrap(fetch_classification(value)))
     project.level_of_identifiability = fetch_level_of_identifiability(value)
   end
 

--- a/app/facades/pdf_application_facade.rb
+++ b/app/facades/pdf_application_facade.rb
@@ -185,7 +185,7 @@ class PdfApplicationFacade
     super && project.valid?
   end
 
-  def save
+  def save(validate: true)
     run_callbacks :save do
       project.transaction do
         create_or_update_applicant!
@@ -199,7 +199,7 @@ class PdfApplicationFacade
         project.lawful_bases.replace(lawful_bases)
         project.classifications.replace(classifications)
 
-        project.save!
+        project.save!(validate: validate)
       end
     end
   rescue ActiveRecord::RecordInvalid => e

--- a/app/facades/pdf_application_facade.rb
+++ b/app/facades/pdf_application_facade.rb
@@ -180,7 +180,7 @@ class PdfApplicationFacade
   end
 
   def valid?
-    (super && project.valid?).tap do
+    (super & project.valid?).tap do
       errors.merge!(project.errors)
     end
   end

--- a/app/facades/pdf_application_facade.rb
+++ b/app/facades/pdf_application_facade.rb
@@ -22,9 +22,7 @@ class PdfApplicationFacade
 
   delegate_missing_to :project
 
-  define_model_callbacks :validate, :save
-
-  after_validate -> { errors.merge!(project.errors) }
+  define_model_callbacks :save
 
   # Leverage dirty attribute tracking to provide a psuedo :attr_readonly and ensure
   # undesirable changes are not persisted on the update path.
@@ -182,7 +180,9 @@ class PdfApplicationFacade
   end
 
   def valid?
-    super && project.valid?
+    (super && project.valid?).tap do
+      errors.merge!(project.errors)
+    end
   end
 
   def save(validate: true)

--- a/app/facades/pdf_application_facade.rb
+++ b/app/facades/pdf_application_facade.rb
@@ -170,7 +170,6 @@ class PdfApplicationFacade
   def initialize(project, attrs = {})
     super(attrs)
     @project = project
-    @project.pdf_import = true
 
     self.end_uses        = project.end_uses.to_set
     self.lawful_bases    = project.lawful_bases.to_set
@@ -188,7 +187,7 @@ class PdfApplicationFacade
   def save(validate: true)
     run_callbacks :save do
       project.transaction do
-        create_or_update_applicant!
+        create_or_update_applicant
 
         # Changes to sub resource collections are deferred until they can be performed as part of
         # this save transaction. Mutating those collections outside of this transaction can be
@@ -319,7 +318,7 @@ class PdfApplicationFacade
   # TODO: This doesn't feel like the right thing to do...
   # QUESTION: Business logic dictates that we do nothing to the applicant on the update path,
   # but why? We can/do update the applicant details on a subsequent _new_ project/import...
-  def create_or_update_applicant!
+  def create_or_update_applicant
     return if persisted?
 
     User.find_or_initialize_by(email: applicant_email&.strip&.downcase).tap do |user|
@@ -330,7 +329,7 @@ class PdfApplicationFacade
 
       user.grants.find_or_initialize_by(roleable: TeamRole.fetch(:mbis_applicant), team: team)
 
-      user.save!
+      user.save
 
       build_owner_grant(user: user)
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -125,10 +125,8 @@ class Project < ApplicationRecord
     validates :project_purpose, presence: true
   end
 
-  attr_accessor :pdf_import
-
   with_options if: -> { odr? } do
-    validates :first_contact_date, presence: true, unless: :pdf_import
+    validates :first_contact_date, presence: true
   end
 
   # Allow for auditing/version tracking of Project

--- a/app/views/projects/_project_grants.html.erb
+++ b/app/views/projects/_project_grants.html.erb
@@ -40,12 +40,14 @@
           </tr>
         </thead>
         <tbody>
-          <tr class="bg-info" id="<%= dom_id(@project.owner) %>">
-            <td><%= @project.owner.full_name %></td>
-            <td><%= "#{@project.owner.email} #{project_owner_text}" %></td>
-            <td></td>
-            <td></td>
-          </tr>
+          <% if @project.owner %>
+            <tr class="bg-info" id="<%= dom_id(@project.owner) %>">
+              <td><%= @project.owner.full_name %></td>
+              <td><%= "#{@project.owner.email} #{project_owner_text}" %></td>
+              <td></td>
+              <td></td>
+            </tr>
+          <% end %>
           <% @project.grants.without_project_owner.each do |grant| %>
             <tr class='project_members_table' id="<%= dom_id(grant.user) %>">
               <% if grant.user.flagged_as_deleted? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,9 @@ en:
           <strong>Note:</strong> Uploading an additional form will not update the applicant,
           organisation or team details.
     import:
+      success: File uploaded successfully!
+      success_with_validity_warning: >
+        File uploaded successfully but project is invalid. Please scroll down and see errors below.
       unpermitted_file_type: 'Unpermitted file type! Expected: "%{expected}" but got "%{got}"'
       ndr_error:
         message_html: >

--- a/test/facades/pdf_application_facade_test.rb
+++ b/test/facades/pdf_application_facade_test.rb
@@ -4,8 +4,12 @@ class PDFApplicationFacadeTest < ActiveSupport::TestCase
   def setup
     @team      = teams(:team_one)
     @applicant = users(:standard_user2)
-    @project   = @team.projects.build(project_type: project_types(:application))
-    @facade    = PdfApplicationFacade.new(@project)
+    @project   = @team.projects.build(
+      project_type: project_types(:application),
+      first_contact_date: Time.zone.today
+    )
+
+    @facade = PdfApplicationFacade.new(@project)
   end
 
   test 'should create a new project' do


### PR DESCRIPTION
This PR is an attempt to at least mitigate the issue of ODR not being able to transition a newly created project via the import route (because validation failure due to missing `first_contact_date`).
<br />

### **TL;DR** - Haven't found a clean solution; here's a hacky one.

#### WARNING - WALL OF TEXT ####

In an ideal world, this would be solved by adding/expanding a `reason_not_to_transition_to_{state}` method with the blocking reason to the states that would be the first interaction ODR have with a project had they not acted as a proxy for the applicant. This would have been a neat solution but is not possible because of the mandate that `first_contact_date` be completed at the earliest possible opportunity (for reporting purposes, from what I gather).

As a means of satisfying the request/ticket, I've changed things around a little so that projects will import regardless of validity (removing the need for validation bypass flags, and making it explicit that we're creating invalid records) and then redirect to show/edit as appropriate, with any validation errors/warnings intact. This gives them the error message they've asked for and prompts for the field to be completed immediately after the import. 

It's not a robust solution however:
- It's possible to hit cancel on the edit screen and leave the project in an invalid state; we're right back to square one if this happens.
- Dealing with an imported project that is invalid for reasons of missing applicant data is going to be a pain to resolve for any user. I've got a potential idea for how to solve this but it's not a trivial amount of work.

On a positive note, this flow feels like it gives a nicer feedback experience than the current modal provides (which I'm sure I saw a ticket for recently).

I think there are a number of other issues surrounding the current handling of `first_contact_date`:
- It's and ODR specific field required for the management of the project...
- ... but it currently requires *any* user creating a project have to complete it
- Having validations that are user context specific feels like a treacherous path to walk. I've played around a bit but nothing has felt quite right to me yet. Some pointers for future reference:
  - Rails validation contexts (https://guides.rubyonrails.org/active_record_validations.html#on)
  - decoration/external validators
    - https://api.rubyonrails.org/v6.0.3.7/classes/ActiveModel/Validator.html
    - https://github.com/rails/rails/blob/v6.0.3.7/activemodel/lib/active_model/validations/with.rb#L137)
- The attribute feels more like project metadata or possibly first class data on some other non-existent resource that specifically handles the ODR/management side of things (and `Project` could then be distilled down to literally being the request for data and nothing more).


Overall, I've tried approaching this quite a few ways now and I can never find a solution that I'm 100% happy with, so I'm taking what I think is the least of all evils (until I change my mind...). Not my finest hour.