### PR TITLE
ODR Reference (application_log) update, pt. 2

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -541,7 +541,7 @@ class Project < ApplicationRecord
       date.strftime('%y')
     end
 
-    "ODR_#{fy_start}#{fy_end}_#{id}"
+    "ODR#{fy_start}#{fy_end}_#{id}"
   end
   alias reference application_log
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -228,7 +228,7 @@ class Project < ApplicationRecord
       filter = arel_table[:application_log].matches("%#{string}%")
 
       return filter unless match ||= string.match(
-        %r(\A(?<head>ODR_(?<fy_start>\d{2})(?<fy_end>\d{2})_?)?(?<id>\d+)?(?<tail>/.*)?\z)i
+        %r(\A(?<head>ODR_?(?<fy_start>\d{2})(?<fy_end>\d{2})_?)?(?<id>\d+)?(?<tail>/.*)?\z)i
       )
 
       chain = []

--- a/test/helpers/projects_helper_test.rb
+++ b/test/helpers/projects_helper_test.rb
@@ -75,7 +75,7 @@ class ProjectsHelperTest < ActionView::TestCase
 
     @project.project_type.stubs(name: 'Application')
     @project.stubs(first_contact_date: Date.parse('2021/03/03'))
-    expected = "<small>ODR Reference: ODR_2021_#{@project.id}</small>"
+    expected = "<small>ODR Reference: ODR2021_#{@project.id}</small>"
     assert_equal expected, odr_reference(@project)
   end
 

--- a/test/integration/project_amendments_test.rb
+++ b/test/integration/project_amendments_test.rb
@@ -56,7 +56,7 @@ class ProjectAmendmentsTest < ActionDispatch::IntegrationTest
       assert has_selector?('#projectAmendments', visible: true)
     end
     assert_equal 1, project.reload.amendment_number
-    expected_amendment_reference = "ODR_1920_#{project.id}/A1"
+    expected_amendment_reference = "ODR1920_#{project.id}/A1"
     assert_equal expected_amendment_reference, project.project_amendments.first.reference
   end
 
@@ -69,7 +69,7 @@ class ProjectAmendmentsTest < ActionDispatch::IntegrationTest
     project.transition_to!(workflow_states(:amend))
 
     amendment = create_amendment(project)
-    amendment_reference = "ODR_1920_#{project.id}/A1"
+    amendment_reference = "ODR1920_#{project.id}/A1"
     assert_equal project.project_amendments.first.reference, amendment_reference
     visit project_path(project)
     click_on('Amendments')

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -579,12 +579,12 @@ class ProjectTest < ActiveSupport::TestCase
 
   test 'returns an ODR application_log based of financialy year and id if application_log is nil' do
     %i[eoi application].each do |type|
-      assert_application_log('ODR_2021_', name: 'application log test 1',
-                                          project_type: project_types(type),
-                                          first_contact_date: Date.parse('2021/03/31'))
-      assert_application_log('ODR_2122_', name: 'application log test 2',
-                                          project_type: project_types(type),
-                                          first_contact_date: Date.parse('2021/04/01'))
+      assert_application_log('ODR2021_', name: 'application log test 1',
+                                         project_type: project_types(type),
+                                         first_contact_date: Date.parse('2021/03/31'))
+      assert_application_log('ODR2122_', name: 'application log test 2',
+                                         project_type: project_types(type),
+                                         first_contact_date: Date.parse('2021/04/01'))
     end
   end
 


### PR DESCRIPTION
Requirements over the formatting of `application_log` have changed again, so here's a PR for that...

- Remove underscore seperator between reference prefix and financial year
- Update application_log filter to accomodate new format
