### PR TITLE
Add dependabot.yml config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    vendor: true
+    open-pull-requests-limit: 0 # Disable gem updates. Does not affect security updates.


### PR DESCRIPTION
This should enable Dependabot to vendor Ruby gems when raising PRs for security updates.

Note that this does **not** enable general updating of bundled gems; that's a conversation for another day.