### PR TITLE
# bundler should not generate errors for deployer account

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,12 @@ unless defined?(BUNDLER_OVERRIDE_MINI_RACER) && BUNDLER_OVERRIDE_MINI_RACER
             end
   require 'fileutils'
   if gem_dir && Dir.exist?(gem_dir)
-    FileUtils.cp "#{gem_dir}/#{gem_fname}", 'vendor/cache/'
+    begin
+      FileUtils.cp "#{gem_dir}/#{gem_fname}", 'vendor/cache/'
+    rescue Errno::EACCES
+      # Deployer account may not have write access to vendor/cache/
+      # (in which case the file in vendor/cache/ is probably already correct)
+    end
   else
     FileUtils.rm_f "vendor/cache/#{gem_fname}"
   end

--- a/vendor/mini_racer-x86_64-linux-ruby27/CentOS7_build_notes_ruby27.txt
+++ b/vendor/mini_racer-x86_64-linux-ruby27/CentOS7_build_notes_ruby27.txt
@@ -62,7 +62,12 @@ Add the following to the Gemfile instead of the existing mini_racer / libv8 entr
             end
   require 'fileutils'
   if gem_dir && Dir.exist?(gem_dir)
-    FileUtils.cp "#{gem_dir}/#{gem_fname}", 'vendor/cache/'
+    begin
+      FileUtils.cp "#{gem_dir}/#{gem_fname}", 'vendor/cache/'
+    rescue Errno::EACCES
+      # Deployer account may not have write access to vendor/cache/
+      # (in which case the file in vendor/cache/ is probably already correct)
+    end
   else
     FileUtils.rm_f "vendor/cache/#{gem_fname}"
   end

--- a/vendor/mini_racer-x86_64-linux-ruby30/CentOS7_build_notes_ruby30.txt
+++ b/vendor/mini_racer-x86_64-linux-ruby30/CentOS7_build_notes_ruby30.txt
@@ -62,7 +62,12 @@ Add the following to the Gemfile instead of the existing mini_racer / libv8 entr
             end
   require 'fileutils'
   if gem_dir && Dir.exist?(gem_dir)
-    FileUtils.cp "#{gem_dir}/#{gem_fname}", 'vendor/cache/'
+    begin
+      FileUtils.cp "#{gem_dir}/#{gem_fname}", 'vendor/cache/'
+    rescue Errno::EACCES
+      # Deployer account may not have write access to vendor/cache/
+      # (in which case the file in vendor/cache/ is probably already correct)
+    end
   else
     FileUtils.rm_f "vendor/cache/#{gem_fname}"
   end


### PR DESCRIPTION
without write access to vendor/cache, plan.io #29148