### PR TITLE
# Add column widths to projects table to stop ui issue on big projects

### DIFF
--- a/app/views/projects/_projects_table.html.erb
+++ b/app/views/projects/_projects_table.html.erb
@@ -1,4 +1,12 @@
 <table data-toggle="table" class="table table-hover" id="projects-table">
+  <col style="width:10%">
+  <col style="width:10%">
+  <col style="width:10%">
+  <col style="width:20%">
+  <col style="width:16%">
+  <col style="width:10%">
+  <col style="width:10%">
+  <col style="width:14%">
   <thead>
     <tr>
       <th>Project Type</th>


### PR DESCRIPTION
Large project names were causing an issue on the projects table. Added column widths to stop this.