### PR TITLE
# Bump mini_racer to 0.6.2, using locally compiled CentOS 7 binaries for Ruby 2.7 and 3.0, plan.io #29148

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,8 @@ GEM
     mini_portile2 (2.8.0)
     mini_racer (0.6.2)
       libv8-node (~> 16.10.0.0)
+    mini_racer (0.6.2-x86_64-linux)
+      libv8-node (~> 16.10.0.0)
     minitest (5.14.4)
     mocha (1.14.0)
     msworddoc-extractor (0.2.0)


### PR DESCRIPTION
# Ensure x86_64-linux mini_racer binaries are used for deployments.