### PR TITLE
Allow domains that are considered "internal" to be configured.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,9 @@ module Mbis
     config.i18n.default_locale    = :en
     config.i18n.fallbacks         = true
     config.i18n.available_locales = %i[en en-odr]
+
+    # TODO: Would be nice to push this out to a YAML file and access via `config_for`
+    # so that we can avoid hardcoding...
+    config.x.user.internal_domains = ['phe.gov.uk', 'ukhsa.gov.uk']
   end
 end


### PR DESCRIPTION
Following organisational splits, we now have "internal" users with email addresses 
across multiple domains.

This PR allows those users that have now had their old PHE email accounts migrated to 
the UKHSA domain, to continue to access and use the system without having their 
accounts locked due to being considered "external".

As per code comments, this could be further tidied up and pushed to a YAML config file 
rather than having a hardcoded list of domains, but that might prove to be a bit of a 
bumpy ride for other devs and CI environments at present, so path of least 
resistance... 
