### PR TITLE
Automatic rubocop corrections on germline importer tests

### DIFF
--- a/test/lib/import/brca/core/brca_test.rb
+++ b/test/lib/import/brca/core/brca_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-#require 'import/utility/pseudonymised_file_wrapper'
+# require 'import/utility/pseudonymised_file_wrapper'
 
 class BrcaTest < ActiveSupport::TestCase
   test 'intialize' do

--- a/test/lib/import/brca/core/pseudonymised_file_wrapper_test.rb
+++ b/test/lib/import/brca/core/pseudonymised_file_wrapper_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
-#require 'import/central_logger'
+# require 'import/central_logger'
 
 class PseudonymisedFileWrapperTest < ActiveSupport::TestCase
   test 'intialize' do
     # file    = Rails.root.join('test', 'fixtures', 'files', 'DUMMY_PSEUDO.pseudo')
     @logger = Import::Log.get_auxiliary_logger
-    assert instance_variable_defined?("@logger")
+    assert instance_variable_defined?('@logger')
   end
 end

--- a/test/lib/import/brca/providers/birmingham/birmingham_handler_newformat_test.rb
+++ b/test/lib/import/brca/providers/birmingham/birmingham_handler_newformat_test.rb
@@ -17,10 +17,10 @@ class BirminghamHandlerNewformatTest < ActiveSupport::TestCase
     @record.raw_fields['indication'] = 'BRCA'
     @record.raw_fields['reason'] = 'MLPA only'
     @record.raw_fields['moleculartestingtype'] = 'MLPA only -ve'
-    @record.raw_fields['report'] = 'Multiplex Ligation-dependent Probe Amplification (MLPA) '\
-    'analysis of all exons of BRCA1 and all exons except 5 and 23'\
-    ' of BRCA2 has been undertaken to detect deletions and duplications.'\
-    ' DNA from this patient has been stored.'
+    @record.raw_fields['report'] = 'Multiplex Ligation-dependent Probe Amplification (MLPA) ' \
+                                   'analysis of all exons of BRCA1 and all exons except 5 and 23' \
+                                   ' of BRCA2 has been undertaken to detect deletions and duplications.' \
+                                   ' DNA from this patient has been stored.'
     @handler.process_genetictestscope(@genotype, @record)
     assert_equal 'Unable to assign BRCA genetictestscope', @genotype.attribute_map['genetictestscope']
   end

--- a/test/lib/import/brca/providers/cambridge/cambridge_handler_test.rb
+++ b/test/lib/import/brca/providers/cambridge/cambridge_handler_test.rb
@@ -10,7 +10,6 @@ class CambridgeHandlerTest < ActiveSupport::TestCase
     @logger = Import::Log.get_logger
   end
 
-
   test 'process_cdna_change' do
     @logger.expects(:debug).with('SUCCESSFUL cdna change parse for: 7994A>G')
     @handler.process_cdna_change(@genotype, @record)

--- a/test/lib/import/brca/providers/leeds/leeds_handler_test.rb
+++ b/test/lib/import/brca/providers/leeds/leeds_handler_test.rb
@@ -16,7 +16,7 @@ class LeedsHandlerTest < ActiveSupport::TestCase
     @handler.add_cdna_change_from_report(@genotype, @record)
     broken_record = build_raw_record('pseudo_id1' => 'bob')
     broken_record.mapped_fields['report'] = 'E;OUHF;A`HFD ;UFHA;S83UROQW QWURHFS;AY093 ;WQFSAH; SA'
-    @logger.expects(:debug).with('FAILED cdna change parse for: E;OUHF;A`HFD ;'\
+    @logger.expects(:debug).with('FAILED cdna change parse for: E;OUHF;A`HFD ;' \
                                  'UFHA;S83UROQW QWURHFS;AY093 ;WQFSAH; SA')
     @handler.add_cdna_change_from_report(@genotype, broken_record)
   end
@@ -35,7 +35,7 @@ class LeedsHandlerTest < ActiveSupport::TestCase
     report = Maybe([@record.raw_fields['report'],
                     @record.mapped_fields['report'],
                     @record.raw_fields['firstofreport']].
-                     reject(&:nil?).first).or_else('') # la report_string
+                     compact.first).or_else('') # la report_string
     geno = Maybe(@record.raw_fields['genotype']).
            or_else(Maybe(@record.raw_fields['report_result']).
            or_else(''))
@@ -46,7 +46,7 @@ class LeedsHandlerTest < ActiveSupport::TestCase
     normal_report = Maybe([normal_record.raw_fields['report'],
                            normal_record.mapped_fields['report'],
                            normal_record.raw_fields['firstofreport']].
-                    reject(&:nil?).first).or_else('') # la report_string
+                    compact.first).or_else('') # la report_string
     normal_geno = Maybe(normal_record.raw_fields['genotype']).
                   or_else(Maybe(normal_record.raw_fields['report_result']).
                   or_else(''))
@@ -79,15 +79,15 @@ class LeedsHandlerTest < ActiveSupport::TestCase
       sortdate: '2019-10-25T00:00:00.000+01:00',
       genetictestscope: 'R208.1',
       specimentype: '5',
-      report: 'This patient has been screened for variants in BRCA1 and BRCA2 by '\
+      report: 'This patient has been screened for variants in BRCA1 and BRCA2 by ' \
               'sequence and dosage analysis.' \
-              'This patient is heterozygous for the '\
-              'BRCA1 sequence variant c.5198A>G p.(Asp1733Gly). '\
-              'This variant involves a moderately-conserved protein position. '\
-              'It is found in population control sets at low frequency, '\
-              'and functional studies suggest that '\
-              'the resultant protein is functional². Evaluation of the available evidence regarding the '\
-              'pathogenicity of this variant remains inconclusive; it is considered to be a variant of '\
+              'This patient is heterozygous for the ' \
+              'BRCA1 sequence variant c.5198A>G p.(Asp1733Gly). ' \
+              'This variant involves a moderately-conserved protein position. ' \
+              'It is found in population control sets at low frequency, ' \
+              'and functional studies suggest that ' \
+              'the resultant protein is functional². Evaluation of the available evidence regarding the ' \
+              'pathogenicity of this variant remains inconclusive; it is considered to be a variant of ' \
               'uncertain significance. Therefore, predictive testing is not indicated for relatives.',
       requesteddate: '2019-10-25T00:00:00.000+01:00',
       age: 999 }.to_json
@@ -105,14 +105,14 @@ class LeedsHandlerTest < ActiveSupport::TestCase
       moleculartestingtype: 'R208.1',
       indicationcategory: 'R208',
       genotype: 'BRCA MS - Diag C3',
-      report: 'This patient has been screened for variants in BRCA1 and BRCA2 by '\
+      report: 'This patient has been screened for variants in BRCA1 and BRCA2 by ' \
               'sequence and dosage analysis.' \
-              'This patient is heterozygous for the '\
-              'BRCA1 sequence variant c.5198A>G p.(Asp1733Gly). '\
-              'This variant involves a moderately-conserved protein position. '\
-              'It is found in population control sets at low frequency, and functional studies suggest that '\
-              'the resultant protein is functional². Evaluation of the available evidence regarding the '\
-              'pathogenicity of this variant remains inconclusive; it is considered to be a variant of '\
+              'This patient is heterozygous for the ' \
+              'BRCA1 sequence variant c.5198A>G p.(Asp1733Gly). ' \
+              'This variant involves a moderately-conserved protein position. ' \
+              'It is found in population control sets at low frequency, and functional studies suggest that ' \
+              'the resultant protein is functional². Evaluation of the available evidence regarding the ' \
+              'pathogenicity of this variant remains inconclusive; it is considered to be a variant of ' \
               'uncertain significance. Therefore, predictive testing is not indicated for relatives.',
       receiveddate: '2019-10-25 00:00:00',
       requesteddate: '2019-10-25 00:00:00',
@@ -130,7 +130,7 @@ class LeedsHandlerTest < ActiveSupport::TestCase
       sortdate: '2019-10-25T00:00:00.000+01:00',
       genetictestscope: 'R208.1',
       specimentype: '5',
-      report: 'This patient has been screened for BRCA1 and BRCA2 '\
+      report: 'This patient has been screened for BRCA1 and BRCA2 ' \
               'mutations by sequence analysis and MLPA. No pathogenic mutation was identified.',
       requesteddate: '2019-10-25T00:00:00.000+01:00',
       age: 999 }.to_json
@@ -148,7 +148,7 @@ class LeedsHandlerTest < ActiveSupport::TestCase
       moleculartestingtype: 'R208.1',
       indicationcategory: 'R208',
       genotype: 'Normal B1/B2 - UNAFFECTED',
-      report: 'This patient has been screened for BRCA1 and BRCA2 '\
+      report: 'This patient has been screened for BRCA1 and BRCA2 ' \
               'mutations by sequence analysis and MLPA. No pathogenic mutation was identified.',
       receiveddate: '2019-10-25 00:00:00',
       requesteddate: ' 2019-10-25 00:00:00',

--- a/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
+++ b/test/lib/import/brca/providers/newcastle/newcastle_handler_test.rb
@@ -12,7 +12,6 @@ class NewcastleHandlerTest < ActiveSupport::TestCase
     @logger = Import::Log.get_logger
   end
 
-
   test 'process_protein_impact' do
     @logger.expects(:debug).with('FAILED protein parse for: c.2597G>A')
     variant = @handler.get_variant(@record)

--- a/test/lib/import/colorectal/core/genotype_mmr_test.rb
+++ b/test/lib/import/colorectal/core/genotype_mmr_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-#require 'import/genotype.rb'
-#require 'import/colorectal/core/genotype_mmr.rb'
-#require 'import/brca/core/provider_handler'
-#require 'import/storage_manager/persister'
+# require 'import/genotype.rb'
+# require 'import/colorectal/core/genotype_mmr.rb'
+# require 'import/brca/core/provider_handler'
+# require 'import/storage_manager/persister'
 
 class GenotypeMmrTest < ActiveSupport::TestCase
   def setup

--- a/test/lib/import/colorectal/providers/birmingham/birmingham_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/birmingham/birmingham_handler_colorectal_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-#require 'import/genotype.rb'
-#require 'import/colorectal/core/genotype_mmr.rb'
-#require 'import/brca/core/provider_handler'
-#require 'import/storage_manager/persister'
+# require 'import/genotype.rb'
+# require 'import/colorectal/core/genotype_mmr.rb'
+# require 'import/brca/core/provider_handler'
+# require 'import/storage_manager/persister'
 
 class BirminghamHandlerColorectalTest < ActiveSupport::TestCase
   def setup

--- a/test/lib/import/colorectal/providers/cambridge/cambridge_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/cambridge/cambridge_handler_colorectal_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-#require 'import/genotype.rb'
-#require 'import/colorectal/core/genotype_mmr.rb'
-#require 'import/brca/core/provider_handler'
-#require 'import/storage_manager/persister'
+# require 'import/genotype.rb'
+# require 'import/colorectal/core/genotype_mmr.rb'
+# require 'import/brca/core/provider_handler'
+# require 'import/storage_manager/persister'
 
 class CambridgeHandlerColorectalTest < ActiveSupport::TestCase
   def setup

--- a/test/lib/import/colorectal/providers/leeds/leeds_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/leeds/leeds_handler_colorectal_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-#require 'import/genotype.rb'
-#require 'import/colorectal/core/genotype_mmr.rb'
-#require 'import/brca/core/provider_handler'
-#require 'import/storage_manager/persister'
+# require 'import/genotype.rb'
+# require 'import/colorectal/core/genotype_mmr.rb'
+# require 'import/brca/core/provider_handler'
+# require 'import/storage_manager/persister'
 
 class LeedsHandlerColorectalTest < ActiveSupport::TestCase
   def setup
@@ -21,10 +21,10 @@ class LeedsHandlerColorectalTest < ActiveSupport::TestCase
   end
 
   test 'failed_teststatus' do
-    @logger.expects(:debug).with('Cannot determine test status for : Analysis showed that this '\
-    'patient is heterozygous for the pathogenic APC mutation c.847C>T (p.Arg283X). '\
-    'This confirms a clinical diagnosis of FAP.\n\nThis result has important implications for '\
-    'other family members at risk and testing may be performed as appropriate. a priori')
+    @logger.expects(:debug).with('Cannot determine test status for : Analysis showed that this ' \
+                                 'patient is heterozygous for the pathogenic APC mutation c.847C>T (p.Arg283X). ' \
+                                 'This confirms a clinical diagnosis of FAP.\n\nThis result has important implications for ' \
+                                 'other family members at risk and testing may be performed as appropriate. a priori')
     @handler.failed_teststatus(@genotype, @record)
   end
 
@@ -37,14 +37,14 @@ class LeedsHandlerColorectalTest < ActiveSupport::TestCase
     assert_equal 'c.847C>T', @genotype.attribute_map['codingdnasequencechange']
     assert_equal 'p.Arg283x', @genotype.attribute_map['proteinimpact']
     normal_record = build_raw_record('pseudo_id1' => 'bob')
-    normal_record.raw_fields['report'] = 'This patient has been screened for MLH1, MSH2, MSH6 and '\
-    'PMS2 mutations by sequence and dosage analysis. No pathogenic mutation was identified.'\
-    '\n\n\n\nThis result does not exclude a diagnosis of Lynch syndrome.\n\nTesting for other '\
-    'genes involved in familial bowel cancer is available if appropriate.'
-    normal_record.mapped_fields['report'] = 'This patient has been screened for MLH1, MSH2, MSH6 and '\
-    'PMS2 mutations by sequence and dosage analysis. No pathogenic mutation was identified.'\
-    '\n\n\n\nThis result does not exclude a diagnosis of Lynch syndrome.\n\nTesting for other '\
-    'genes involved in familial bowel cancer is available if appropriate.'
+    normal_record.raw_fields['report'] = 'This patient has been screened for MLH1, MSH2, MSH6 and ' \
+                                         'PMS2 mutations by sequence and dosage analysis. No pathogenic mutation was identified.' \
+                                         '\n\n\n\nThis result does not exclude a diagnosis of Lynch syndrome.\n\nTesting for other ' \
+                                         'genes involved in familial bowel cancer is available if appropriate.'
+    normal_record.mapped_fields['report'] = 'This patient has been screened for MLH1, MSH2, MSH6 and ' \
+                                            'PMS2 mutations by sequence and dosage analysis. No pathogenic mutation was identified.' \
+                                            '\n\n\n\nThis result does not exclude a diagnosis of Lynch syndrome.\n\nTesting for other ' \
+                                            'genes involved in familial bowel cancer is available if appropriate.'
     @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: ["MLH1"]')
     @logger.expects(:debug).with('SUCCESSFUL gene parse for MLH1')
     @logger.expects(:debug).with('SUCCESSFUL gene parse for negative test for: ["MSH2"]')
@@ -73,9 +73,9 @@ class LeedsHandlerColorectalTest < ActiveSupport::TestCase
       sortdate: '2010-08-05T00:00:00.000+01:00',
       genetictestscope: 'Diagnostic',
       specimentype: '5',
-      report: 'Analysis showed that this patient is heterozygous for the pathogenic'\
-              ' APC mutation c.847C>T (p.Arg283X). '\
-              'This confirms a clinical diagnosis of FAP.\n\nThis result has important implications '\
+      report: 'Analysis showed that this patient is heterozygous for the pathogenic' \
+              ' APC mutation c.847C>T (p.Arg283X). ' \
+              'This confirms a clinical diagnosis of FAP.\n\nThis result has important implications ' \
               'for other family members at risk and testing may be performed as appropriate.',
       requesteddate: '2010-08-05T00:00:00.000+01:00',
       age: 99999 }.to_json
@@ -93,9 +93,9 @@ class LeedsHandlerColorectalTest < ActiveSupport::TestCase
       moleculartestingtype: 'Diagnostic',
       indicationcategory: '17510',
       genotype: 'Diagnostic APC +ve',
-      report: 'Analysis showed that this patient is heterozygous for the pathogenic '\
-              'APC mutation c.847C>T (p.Arg283X). This confirms a clinical diagnosis of FAP.\n\n'\
-              'This result has important implications for other family members at risk and testing '\
+      report: 'Analysis showed that this patient is heterozygous for the pathogenic ' \
+              'APC mutation c.847C>T (p.Arg283X). This confirms a clinical diagnosis of FAP.\n\n' \
+              'This result has important implications for other family members at risk and testing ' \
               'may be performed as appropriate.',
       receiveddate: '2010-08-05 00:00:00',
       requesteddate: '2010-08-05 00:00:00',

--- a/test/lib/import/colorectal/providers/london_gosh/london_gosh_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/london_gosh/london_gosh_handler_colorectal_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-#require 'import/genotype.rb'
-#require 'import/colorectal/core/genotype_mmr.rb'
-#require 'import/brca/core/provider_handler'
-#require 'import/storage_manager/persister'
+# require 'import/genotype.rb'
+# require 'import/colorectal/core/genotype_mmr.rb'
+# require 'import/brca/core/provider_handler'
+# require 'import/storage_manager/persister'
 
 class LondonGoshHandlerColorectalTest < ActiveSupport::TestCase
   def setup
@@ -43,8 +43,12 @@ class LondonGoshHandlerColorectalTest < ActiveSupport::TestCase
     cdna_record.raw_fields['acmg_protein_change'] = 'p.Val717Alafs*18'
     genotypes = []
     mutated_gene = cdna_record.raw_fields['gene']
-    all_genes = cdna_record.raw_fields['genes analysed'] unless cdna_record.raw_fields['genes analysed'].nil?
-    dna_variant = cdna_record.raw_fields['acmg_cdna'] unless cdna_record.raw_fields['acmg_cdna'].nil?
+    unless cdna_record.raw_fields['genes analysed'].nil?
+      all_genes = cdna_record.raw_fields['genes analysed']
+    end
+    unless cdna_record.raw_fields['acmg_cdna'].nil?
+      dna_variant = cdna_record.raw_fields['acmg_cdna']
+    end
     protein_variant = cdna_record.raw_fields['acmg_protein_change']
     @logger.expects(:debug).with('Found mutated gene MLH1')
     @logger.expects(:debug).with('Negative genes are ["EPCAM", "MSH2", "MSH6"]')
@@ -61,8 +65,12 @@ class LondonGoshHandlerColorectalTest < ActiveSupport::TestCase
     exon_record.raw_fields['codingdnasequencechange'] = 'MSH2 exon 11-16 deletion'
     genotypes = []
     mutated_gene = exon_record.raw_fields['gene']
-    all_genes = exon_record.raw_fields['genes analysed'] unless exon_record.raw_fields['genes analysed'].nil?
-    exonic_variant = exon_record.raw_fields['codingdnasequencechange'] unless exon_record.raw_fields['codingdnasequencechange'].nil?
+    unless exon_record.raw_fields['genes analysed'].nil?
+      all_genes = exon_record.raw_fields['genes analysed']
+    end
+    unless exon_record.raw_fields['codingdnasequencechange'].nil?
+      exonic_variant = exon_record.raw_fields['codingdnasequencechange']
+    end
     @logger.expects(:debug).with('Found mutated gene MLH1 for insertion deletion duplication')
     @logger.expects(:debug).with('Found mutated deletion for insertion deletion duplication')
     @logger.expects(:debug).with('Found exon(s) 11-16 for insertion deletion duplication')
@@ -80,7 +88,9 @@ class LondonGoshHandlerColorectalTest < ActiveSupport::TestCase
     negative_record.raw_fields['codingdnasequencechange'] = 'MSH2 exon 11-16 deletion'
     genotypes = []
     mutated_gene = negative_record.raw_fields['gene']
-    all_genes = negative_record.raw_fields['genes analysed'] unless negative_record.raw_fields['genes analysed'].nil?
+    unless negative_record.raw_fields['genes analysed'].nil?
+      all_genes = negative_record.raw_fields['genes analysed']
+    end
     @logger.expects(:debug).with('Negative genes are ["EPCAM", "MSH2", "MSH6"]')
     @logger.expects(:debug).with('SUCCESSFUL gene parse for EPCAM')
     @logger.expects(:debug).with('SUCCESSFUL gene parse for MSH2')

--- a/test/lib/import/colorectal/providers/london_kgc/london_kgc_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/london_kgc/london_kgc_handler_colorectal_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-#require 'import/genotype.rb'
-#require 'import/colorectal/core/genotype_mmr.rb'
-#require 'import/brca/core/provider_handler'
-#require 'import/storage_manager/persister'
+# require 'import/genotype.rb'
+# require 'import/colorectal/core/genotype_mmr.rb'
+# require 'import/brca/core/provider_handler'
+# require 'import/storage_manager/persister'
 
 class LondonKgcHandlerColorectalTest < ActiveSupport::TestCase
   def setup
@@ -14,7 +14,6 @@ class LondonKgcHandlerColorectalTest < ActiveSupport::TestCase
     end
     @logger = Import::Log.get_logger
   end
-
 
   test 'process_lynchgenes with no mutation' do
     genemutation_lynch_record = build_raw_record('pseudo_id1' => 'bob')

--- a/test/lib/import/colorectal/providers/manchester/manchester_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/manchester/manchester_handler_colorectal_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-#require 'import/genotype'
-#require 'import/colorectal/core/genotype_mmr'
-#require 'import/brca/core/provider_handler'
-#require 'import/storage_manager/persister'
+# require 'import/genotype'
+# require 'import/colorectal/core/genotype_mmr'
+# require 'import/brca/core/provider_handler'
+# require 'import/storage_manager/persister'
 class ManchesterHandlerColorectalTest < ActiveSupport::TestCase
   def setup
     @importer_stdout, @importer_stderr = capture_io do

--- a/test/lib/import/colorectal/providers/nottingham/nottingham_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/nottingham/nottingham_handler_colorectal_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-#require 'import/genotype.rb'
-#require 'import/colorectal/core/genotype_mmr.rb'
-#require 'import/brca/core/provider_handler'
-#require 'import/storage_manager/persister'
+# require 'import/genotype.rb'
+# require 'import/colorectal/core/genotype_mmr.rb'
+# require 'import/brca/core/provider_handler'
+# require 'import/storage_manager/persister'
 
 class NottinghamHandlerColorectalTest < ActiveSupport::TestCase
   def setup

--- a/test/lib/import/colorectal/providers/oxford/oxford_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/oxford/oxford_handler_colorectal_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-#require 'import/genotype.rb'
-#require 'import/colorectal/core/genotype_mmr.rb'
-#require 'import/brca/core/provider_handler'
-#require 'import/storage_manager/persister'
+# require 'import/genotype.rb'
+# require 'import/colorectal/core/genotype_mmr.rb'
+# require 'import/brca/core/provider_handler'
+# require 'import/storage_manager/persister'
 
 class OxfordHandlerColorectalTest < ActiveSupport::TestCase
   def setup

--- a/test/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/royal_marsden/royal_marsden_handler_colorectal_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
-#require 'import/genotype.rb'
-#require 'import/colorectal/core/genotype_mmr.rb'
-#require 'import/brca/core/provider_handler'
-#require 'import/storage_manager/persister'
+# require 'import/genotype.rb'
+# require 'import/colorectal/core/genotype_mmr.rb'
+# require 'import/brca/core/provider_handler'
+# require 'import/storage_manager/persister'
 
 class RoyalMarsdenHandlerColorectalTest < ActiveSupport::TestCase
   def setup

--- a/test/lib/import/colorectal/providers/salisbury/salisbury_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/salisbury/salisbury_handler_colorectal_test.rb
@@ -45,7 +45,7 @@ class SalisburyHandlerColorectalTest < ActiveSupport::TestCase
     multigene_multicnv_variants_record = build_raw_record('pseudo_id1' => 'bob')
     multigene_multicnv_variants_record.raw_fields['test'] = 'MLH1 and MSH2 test'
     multigene_multicnv_variants_record.raw_fields['status'] = 'Pathogenic'
-    multigene_multicnv_variants_record.raw_fields['genotype'] = 'Heterozygous deletion including '\
+    multigene_multicnv_variants_record.raw_fields['genotype'] = 'Heterozygous deletion including ' \
                                                                 'MSH2 exons 1-7 and EPCAM exon 9'
     res = @handler.add_colorectal_from_raw_test(@genotype, multigene_multicnv_variants_record)
     assert_equal 3, res.size

--- a/test/lib/import/colorectal/providers/sheffield/sheffield_handler_colorectal_test.rb
+++ b/test/lib/import/colorectal/providers/sheffield/sheffield_handler_colorectal_test.rb
@@ -10,7 +10,6 @@ class SheffieldHandlerColorectalTest < ActiveSupport::TestCase
     @logger = Import::Log.get_logger
   end
 
-
   test 'add_test_scope_from_karyo_fullscreen' do
     @handler.add_test_scope_from_geno_karyo(@genotype, @record)
     assert_equal 'Full screen Colorectal Lynch or MMR', @genotype.attribute_map['genetictestscope']


### PR DESCRIPTION
`rubocop -A test/lib/import/` run, no manual corrections